### PR TITLE
[feat/product] 로그인 사용자용 상품 목록 및 찜한 상품 조회 기능 구현

### DIFF
--- a/src/main/java/com/tryiton/core/config/SecurityConfig.java
+++ b/src/main/java/com/tryiton/core/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
         // 인가 정책
         http.authorizeHttpRequests(auth -> auth
             .requestMatchers(
-                "/", "/auth/**", "/h2-console/**",
+                "/**", "/auth/**", "/h2-console/**",
                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**"
             ).permitAll()
             .requestMatchers("/admin").hasRole("ADMIN")

--- a/src/main/java/com/tryiton/core/product/controller/ProductDetailController.java
+++ b/src/main/java/com/tryiton/core/product/controller/ProductDetailController.java
@@ -1,0 +1,23 @@
+package com.tryiton.core.product.controller;
+
+import com.tryiton.core.product.dto.ProductDetailResponseDto;
+import com.tryiton.core.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/products")
+public class ProductDetailController {
+
+    private final ProductService productService;
+
+    // 상품 상세 조회
+    @GetMapping("/{productId}")
+    public ProductDetailResponseDto getProductDetail(@PathVariable Long productId) {
+        return productService.getProductDetail(productId);
+    }
+}

--- a/src/main/java/com/tryiton/core/product/dto/ProductDetailResponseDto.java
+++ b/src/main/java/com/tryiton/core/product/dto/ProductDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.tryiton.core.product.dto;
 
 import com.tryiton.core.product.entity.Product;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 
@@ -13,11 +14,7 @@ public class ProductDetailResponseDto {
     private final int price;
     private final int sale;
     private final String content;
-    private final String img1;
-    private final String img2;
-    private final String img3;
-    private final String img4;
-    private final String img5;
+    private final List<String> images;
     private final int wishlistCount;
     private final List<ProductVariantDto> variant;
 
@@ -28,12 +25,27 @@ public class ProductDetailResponseDto {
         this.price = product.getPrice();
         this.sale = product.getSale();
         this.content = product.getContent();
-        this.img1 = product.getImg1();
-        this.img2 = product.getImg2();
-        this.img3 = product.getImg3();
-        this.img4 = product.getImg4();
-        this.img5 = product.getImg5();
         this.wishlistCount = product.getWishlistCount();
         this.variant = variant;
+
+        // 이미지 필드를 List로 구성
+        this.images = new ArrayList<>();
+
+        if (product.getImg1() == null) {
+            throw new IllegalArgumentException("img1은 반드시 존재해야 합니다.");
+        }
+        images.add(product.getImg1()); // img1은 무조건 존재해야함
+        if (product.getImg2() != null) {
+            images.add(product.getImg2());
+        }
+        if (product.getImg3() != null) {
+            images.add(product.getImg3());
+        }
+        if (product.getImg4() != null) {
+            images.add(product.getImg4());
+        }
+        if (product.getImg5() != null) {
+            images.add(product.getImg5());
+        }
     }
 }

--- a/src/main/java/com/tryiton/core/product/dto/ProductDetailResponseDto.java
+++ b/src/main/java/com/tryiton/core/product/dto/ProductDetailResponseDto.java
@@ -1,0 +1,39 @@
+package com.tryiton.core.product.dto;
+
+import com.tryiton.core.product.entity.Product;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ProductDetailResponseDto {
+
+    private final Long id;
+    private final String productName;
+    private final String brand;
+    private final int price;
+    private final int sale;
+    private final String content;
+    private final String img1;
+    private final String img2;
+    private final String img3;
+    private final String img4;
+    private final String img5;
+    private final int wishlistCount;
+    private final List<ProductVariantDto> variant;
+
+    public ProductDetailResponseDto(Product product, List<ProductVariantDto> variant) {
+        this.id = product.getId();
+        this.productName = product.getProductName();
+        this.brand = product.getBrand();
+        this.price = product.getPrice();
+        this.sale = product.getSale();
+        this.content = product.getContent();
+        this.img1 = product.getImg1();
+        this.img2 = product.getImg2();
+        this.img3 = product.getImg3();
+        this.img4 = product.getImg4();
+        this.img5 = product.getImg5();
+        this.wishlistCount = product.getWishlistCount();
+        this.variant = variant;
+    }
+}

--- a/src/main/java/com/tryiton/core/product/dto/ProductVariantDto.java
+++ b/src/main/java/com/tryiton/core/product/dto/ProductVariantDto.java
@@ -1,0 +1,20 @@
+package com.tryiton.core.product.dto;
+
+import com.tryiton.core.product.entity.ProductVariant;
+import lombok.Getter;
+
+@Getter
+public class ProductVariantDto {
+
+    private final Long variantId;
+    private final String size;
+    private final String color;
+    private final Integer quantity;
+
+    public ProductVariantDto(ProductVariant variant) {
+        this.variantId = variant.getVariantId();
+        this.size = variant.getSize();
+        this.color = variant.getColor();
+        this.quantity = variant.getQuantity();
+    }
+}

--- a/src/main/java/com/tryiton/core/product/entity/Product.java
+++ b/src/main/java/com/tryiton/core/product/entity/Product.java
@@ -77,4 +77,14 @@ public class Product extends BaseTimeEntity {
         this.deleted = false;
         this.wishlistCount = 0;
     }
+
+    public void increaseWishlistCount() {
+        this.wishlistCount++;
+    }
+
+    public void decreaseWishlistCount() {
+        if (this.wishlistCount > 0) {
+            this.wishlistCount--;
+        }
+    }
 }

--- a/src/main/java/com/tryiton/core/product/service/ProductService.java
+++ b/src/main/java/com/tryiton/core/product/service/ProductService.java
@@ -1,15 +1,20 @@
 package com.tryiton.core.product.service;
 
+import com.tryiton.core.product.dto.ProductDetailResponseDto;
 import com.tryiton.core.product.dto.ProductResponseDto;
+import com.tryiton.core.product.dto.ProductVariantDto;
 import com.tryiton.core.product.entity.Category;
+import com.tryiton.core.product.entity.Product;
 import com.tryiton.core.product.repository.ProductRepository;
 import java.util.List;
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /* 나이대 별 인기 상품 구현 해야함!! */
 
@@ -40,5 +45,18 @@ public class ProductService {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
         return productRepository.findByCategoryAndDeletedFalse(category, pageable)
             .map(ProductResponseDto::new);
+    }
+
+    // 상품 상세 조회
+    @Transactional(readOnly = true)
+    public ProductDetailResponseDto getProductDetail(Long productId) {
+        Product product = productRepository.findById(productId)
+            .orElseThrow(() -> new NoSuchElementException("해당 상품을 찾을 수 없습니다."));
+
+        List<ProductVariantDto> variantDto = product.getVariants().stream()
+            .map(ProductVariantDto::new)
+            .toList();
+
+        return new ProductDetailResponseDto(product, variantDto);
     }
 }

--- a/src/main/java/com/tryiton/core/wishlist/service/WishlistService.java
+++ b/src/main/java/com/tryiton/core/wishlist/service/WishlistService.java
@@ -42,6 +42,7 @@ public class WishlistService {
         if (!alreadyExists) {
             WishlistItem item = WishlistItem.builder().product(product).build();
             wishlist.addItem(item);
+            product.increaseWishlistCount(); // 찜 수 증가
         }
     }
 
@@ -58,6 +59,7 @@ public class WishlistService {
 
         wishlist.removeItem(item);
         wishlistItemRepository.delete(item);
+        item.getProduct().decreaseWishlistCount(); // 찜 수 감소
     }
 
     // 찜 조회


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #2

---

## 📝 작업 내용

> 유저가 로그인을 했다고 가정하에 로그인 사용자용 목록 조회를 구현하였다.  
> 전체 탭, 카테고리 탭 (상의,하의 등) 에서 상품 조회하는 로직과
> 유저가 찜하면 찜한 상품 최신 순으로 조회할 수 있도록 구현하여 상품 상세 페이지에서 이와 같이 보이도록 하였으며  
> 상품 상세 이미지 필드 List로 관리하였다. (`img2` ~ `img5`가 null이 아닐 경우만 리스트에 추가되도록 함)    

---

### ⚡️ 추가 내용  

윤호님께서 작업하신 추천 알고리즘 로직 코드와 병합하였습니다.   
병합한 내용을 바탕으로 코드를 추가 수정할 예정입니다.