### PR TITLE
[feat/auth] Member 엔티티에 아바타 이미지, 유저 전신 사진 필드 추가

### DIFF
--- a/src/main/java/com/tryiton/core/auth/email/dto/EmailSigninRequestDto.java
+++ b/src/main/java/com/tryiton/core/auth/email/dto/EmailSigninRequestDto.java
@@ -1,10 +1,14 @@
 package com.tryiton.core.auth.email.dto;
 
+import com.tryiton.core.member.dto.SigninRequestDto;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 @Getter @Setter
-public class EmailSigninRequestDto {
-    private String email;
-    private String password;
+@SuperBuilder
+@NoArgsConstructor
+public class EmailSigninRequestDto extends SigninRequestDto {
+
 }

--- a/src/main/java/com/tryiton/core/auth/email/dto/EmailSigninResponseDto.java
+++ b/src/main/java/com/tryiton/core/auth/email/dto/EmailSigninResponseDto.java
@@ -1,12 +1,14 @@
 package com.tryiton.core.auth.email.dto;
 
-import lombok.AllArgsConstructor;
+import com.tryiton.core.member.dto.SigninResponseDto;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
-@Getter
-@AllArgsConstructor
-public class EmailSigninResponseDto {
-    private String username;
-    private String email;
-    private String accessToken;
+@Getter @Setter
+@SuperBuilder
+@NoArgsConstructor
+public class EmailSigninResponseDto extends SigninResponseDto {
+
 }

--- a/src/main/java/com/tryiton/core/auth/email/dto/EmailSignupRequestDto.java
+++ b/src/main/java/com/tryiton/core/auth/email/dto/EmailSignupRequestDto.java
@@ -1,28 +1,17 @@
 package com.tryiton.core.auth.email.dto;
 
-import java.time.LocalDate;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import com.tryiton.core.member.dto.SignupRequestDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 @Getter @Setter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
-public class EmailSignupRequestDto {
+public class EmailSignupRequestDto extends SignupRequestDto {
 
     private String email;
     private String password;
-    private String username;
-    private LocalDate birthDate;
-    private String gender;
-    private String phoneNum;
     private String profileImageUrl;
-
-    private String preferredStyle;
-    private Integer height;
-    private Integer weight;
-    private Integer shoeSize;
 }

--- a/src/main/java/com/tryiton/core/auth/email/dto/EmailSignupResponseDto.java
+++ b/src/main/java/com/tryiton/core/auth/email/dto/EmailSignupResponseDto.java
@@ -1,21 +1,20 @@
 package com.tryiton.core.auth.email.dto;
 
+import com.tryiton.core.member.dto.SignupResponseDto;
 import com.tryiton.core.member.entity.Member;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
-@AllArgsConstructor
-public class EmailSignupResponseDto {
-    private String email;
-    private String username;
+@SuperBuilder
+@NoArgsConstructor
+public class EmailSignupResponseDto extends SignupResponseDto {
 
-    public static EmailSignupResponseDto from(Member member) {
+    public static EmailSignupResponseDto from(Member saved) {
         return EmailSignupResponseDto.builder()
-            .email(member.getEmail())
-            .username(member.getUsername())
+            .email(saved.getEmail())
+            .username(saved.getUsername())
             .build();
     }
 }

--- a/src/main/java/com/tryiton/core/auth/email/service/EmailAuthService.java
+++ b/src/main/java/com/tryiton/core/auth/email/service/EmailAuthService.java
@@ -154,6 +154,10 @@ public class EmailAuthService {
         }
 
         String token = jwtUtil.createJwt(member.getEmail(), member.getRole().name(), 60 * 60 * 1000L);
-        return new EmailSigninResponseDto(member.getUsername(), member.getEmail(), token);
+        return (EmailSigninResponseDto) EmailSigninResponseDto.builder()
+            .username(member.getUsername())
+            .email(member.getEmail())
+            .accessToken(token)
+            .build();
     }
 }

--- a/src/main/java/com/tryiton/core/auth/oauth/controller/GoogleAuthController.java
+++ b/src/main/java/com/tryiton/core/auth/oauth/controller/GoogleAuthController.java
@@ -1,11 +1,11 @@
 package com.tryiton.core.auth.oauth.controller;
 
+import com.tryiton.core.auth.oauth.dto.GoogleSigninResponseDto;
 import com.tryiton.core.auth.oauth.service.AuthService;
 import com.tryiton.core.auth.oauth.dto.GoogleSigninRequestDto;
 import com.tryiton.core.auth.oauth.dto.GoogleSignupRequestDto;
 import com.tryiton.core.auth.oauth.dto.GoogleSignupResponseDto;
 import com.tryiton.core.common.exception.BusinessException;
-import com.tryiton.core.member.dto.SigninResponseDto;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +26,7 @@ public class GoogleAuthController {
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody GoogleSigninRequestDto dto) {
         try {
-            SigninResponseDto response = authService.loginWithGoogle(dto);
+            GoogleSigninResponseDto response = authService.loginWithGoogle(dto);
             return ResponseEntity.ok(response);
         } catch (BusinessException e) {
             return ResponseEntity

--- a/src/main/java/com/tryiton/core/auth/oauth/dto/GoogleSigninResponseDto.java
+++ b/src/main/java/com/tryiton/core/auth/oauth/dto/GoogleSigninResponseDto.java
@@ -1,5 +1,6 @@
-package com.tryiton.core.member.dto;
+package com.tryiton.core.auth.oauth.dto;
 
+import com.tryiton.core.member.dto.SigninResponseDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,8 +9,6 @@ import lombok.experimental.SuperBuilder;
 @Getter @Setter
 @SuperBuilder
 @NoArgsConstructor
-// Google, Email DTO로 확장
-public class SigninRequestDto {
-    private String email;
-    private String password;
+public class GoogleSigninResponseDto extends SigninResponseDto {
+
 }

--- a/src/main/java/com/tryiton/core/auth/oauth/dto/GoogleSignupRequestDto.java
+++ b/src/main/java/com/tryiton/core/auth/oauth/dto/GoogleSignupRequestDto.java
@@ -1,19 +1,14 @@
 package com.tryiton.core.auth.oauth.dto;
 
-import java.time.LocalDate;
+import com.tryiton.core.member.dto.SignupRequestDto;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-public class GoogleSignupRequestDto {
-    private String username;
-    private LocalDate birthDate;
-    private String gender;
-    private String phoneNum;
-
-    private String preferredStyle;
-    private Integer height;  // cm
-    private Integer weight;  // kg
-    private Integer shoeSize;
+@SuperBuilder
+@NoArgsConstructor
+public class GoogleSignupRequestDto extends SignupRequestDto {
 
     private String idToken;
 }

--- a/src/main/java/com/tryiton/core/auth/oauth/dto/GoogleSignupResponseDto.java
+++ b/src/main/java/com/tryiton/core/auth/oauth/dto/GoogleSignupResponseDto.java
@@ -1,15 +1,16 @@
 package com.tryiton.core.auth.oauth.dto;
 
+import com.tryiton.core.member.dto.SignupResponseDto;
 import com.tryiton.core.member.entity.Member;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
-public class GoogleSignupResponseDto {
+@SuperBuilder
+@NoArgsConstructor
+public class GoogleSignupResponseDto extends SignupResponseDto {
 
-    private String email;
-    private String username;
     private String accessToken;
 
     public static GoogleSignupResponseDto from(Member member, String accessToken) {

--- a/src/main/java/com/tryiton/core/member/dto/SigninResponseDto.java
+++ b/src/main/java/com/tryiton/core/member/dto/SigninResponseDto.java
@@ -1,10 +1,13 @@
 package com.tryiton.core.member.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@AllArgsConstructor
+@SuperBuilder
+@NoArgsConstructor
+// Google, Email DTO로 확장
 public class SigninResponseDto {
     private String username;
     private String email;

--- a/src/main/java/com/tryiton/core/member/dto/SignupRequestDto.java
+++ b/src/main/java/com/tryiton/core/member/dto/SignupRequestDto.java
@@ -1,22 +1,26 @@
 package com.tryiton.core.member.dto;
 
 import java.time.LocalDate;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
-@Getter
-@AllArgsConstructor
+@Getter @Setter
+@SuperBuilder
+@NoArgsConstructor
+// Google, Email DTO로 확장
 public class SignupRequestDto {
-    private String email;
-    private String password;
     private String username;
     private LocalDate birthDate;
     private String gender;
     private String phoneNum;
-    private String profileImageUrl;
 
     private String preferredStyle;
     private Integer height;
     private Integer weight;
     private Integer shoeSize;
+
+    private String avatarBaseImageUrl;
+    private String userBaseImageUrl;
 }

--- a/src/main/java/com/tryiton/core/member/dto/SignupResponseDto.java
+++ b/src/main/java/com/tryiton/core/member/dto/SignupResponseDto.java
@@ -1,21 +1,15 @@
 package com.tryiton.core.member.dto;
 
-import com.tryiton.core.member.entity.Member;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
-@Getter
-@Builder
-@AllArgsConstructor
+@Getter @Setter
+@SuperBuilder
+@NoArgsConstructor
+// Google, Email DTO로 확장
 public class SignupResponseDto {
     private String email;
     private String username;
-
-    public static SignupResponseDto from(Member member) {
-        return SignupResponseDto.builder()
-            .email(member.getEmail())
-            .username(member.getUsername())
-            .build();
-    }
 }

--- a/src/main/java/com/tryiton/core/member/entity/Profile.java
+++ b/src/main/java/com/tryiton/core/member/entity/Profile.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
@@ -48,4 +47,10 @@ public class Profile {
 
     @Column(name = "profile_image_url")
     private String profileImageUrl;
+
+    @Column(name = "user_base_image_url")
+    private String userBaseImageUrl;
+
+    @Column(name = "avatar_base_image_url", nullable = false)
+    private String avatarBaseImageUrl;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #1

---

## 📝 작업 내용
1. DTO 중복 리팩터링
로그인, 회원가입 절차가 두 가지 갈래로 구현되어 중복되는 DTO를 Member 도메인 내에 base DTO로 정의하였습니다.
   - OAuth Google의 로그인, 회원가입 로직에서 DTO를 base DTO에서 상속받아 추가 정보가 필요한 부분을 추가하였습니다.
   - 이메일 인증 로그인, 회원가입 또한 base DTO를 상속받아 일관되고 확장성 있는 코드로 리팩터링하였습니다.

2. Member 엔티티 수정
   - 아바타 기본 이미지(`avatarBaseImageUrl `) 필드 추가
   - 사용자 입력 전신 이미지(`userBaseImageUrl `) 필드 추가
---
