### PR TITLE
[fix/closet] Closet 로직의 avatar 정보 처리 수정

### DIFF
--- a/src/main/java/com/tryiton/core/avatar/entity/Avatar.java
+++ b/src/main/java/com/tryiton/core/avatar/entity/Avatar.java
@@ -1,5 +1,6 @@
 package com.tryiton.core.avatar.entity;
 
+import com.tryiton.core.closet.entity.ClosetAvatarItem;
 import com.tryiton.core.common.BaseTimeEntity;
 import com.tryiton.core.common.exception.BusinessException;
 import com.tryiton.core.member.entity.Member;
@@ -22,9 +23,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.BatchSize;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.parameters.P;
 
 @Entity
 @Getter
@@ -73,11 +72,6 @@ public class Avatar extends BaseTimeEntity {
         // lazy loading 문제를 피하기 위해 컬렉션 접근을 하지 않음
         // JPA가 자동으로 양방향 관계를 관리하도록 함
 //        member.getAvatars().add(this);
-    }
-
-    public void addItem(AvatarItem item) {
-        items.add(item);
-        item.setAvatar(this);
     }
 
     public void update(String avatarImg) {

--- a/src/main/java/com/tryiton/core/closet/controller/ClosetAvatarController.java
+++ b/src/main/java/com/tryiton/core/closet/controller/ClosetAvatarController.java
@@ -37,12 +37,13 @@ public class ClosetAvatarController {
 
     // 아바타 착장 저장
     @PostMapping
-    public ResponseEntity<Void> saveClosetAvatar(
+    public ResponseEntity<Boolean> saveClosetAvatar(
         @AuthenticationPrincipal CustomUserDetails userDetails,
         @RequestBody ClosetAvatarSaveRequestDto requestDto) {
         Member member = userDetails.getUser();
         closetAvatarService.saveClosetAvatar(member, requestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).build(); // 201 Created
+        return ResponseEntity.ok(true);
+//        return ResponseEntity.status(HttpStatus.CREATED).build(); // 201 Created
     }
 
     // 착장 삭제

--- a/src/main/java/com/tryiton/core/closet/dto/ClosetAvatarSaveRequestDto.java
+++ b/src/main/java/com/tryiton/core/closet/dto/ClosetAvatarSaveRequestDto.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 public class ClosetAvatarSaveRequestDto {
 
-    private String avatarImage;
+//    private String avatarImage;
     private List<ClosetAvatarItemRequestDto> items;
 }

--- a/src/main/java/com/tryiton/core/closet/entity/ClosetAvatarItem.java
+++ b/src/main/java/com/tryiton/core/closet/entity/ClosetAvatarItem.java
@@ -1,5 +1,6 @@
 package com.tryiton.core.closet.entity;
 
+import com.tryiton.core.avatar.entity.Avatar;
 import com.tryiton.core.product.entity.Product;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,9 +14,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
-@Getter
+@Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ClosetAvatarItem {
 
@@ -52,4 +54,5 @@ public class ClosetAvatarItem {
     public int hashCode() {
         return id != null ? id.hashCode() : 0;
     }
+
 }

--- a/src/main/java/com/tryiton/core/closet/service/ClosetAvatarService.java
+++ b/src/main/java/com/tryiton/core/closet/service/ClosetAvatarService.java
@@ -1,5 +1,7 @@
 package com.tryiton.core.closet.service;
 
+import com.tryiton.core.avatar.entity.Avatar;
+import com.tryiton.core.avatar.repository.AvatarRepository;
 import com.tryiton.core.closet.dto.ClosetAvatarItemRequestDto;
 import com.tryiton.core.closet.dto.ClosetAvatarResponseDto;
 import com.tryiton.core.closet.dto.ClosetAvatarSaveRequestDto;
@@ -23,6 +25,7 @@ public class ClosetAvatarService {
 
     private final ClosetAvatarRepository closetAvatarRepository;
     private final ProductRepository productRepository;
+    private final AvatarRepository avatarRepository;
 
     // 옷장 전체 조회
     @Transactional(readOnly = true)
@@ -68,9 +71,11 @@ public class ClosetAvatarService {
 
     // 새로운 ClosetAvatar 생성
     private ClosetAvatar createClosetAvatar(Member user, ClosetAvatarSaveRequestDto requestDto) {
-        ClosetAvatar avatar = ClosetAvatar.builder()
+        Avatar avatar = avatarRepository.findTopByMemberIdOrderByCreatedAtDesc(user.getId());
+
+        ClosetAvatar closetAvatar = ClosetAvatar.builder()
             .user(user)
-            .avatarImage(requestDto.getAvatarImage())
+            .avatarImage(avatar.getAvatarImg())
             .build();
 
         for (ClosetAvatarItemRequestDto itemDto : requestDto.getItems()) {
@@ -81,11 +86,11 @@ public class ClosetAvatarService {
             ClosetAvatarItem item = ClosetAvatarItem.builder()
                 .product(product)
                 .build();
-            
-            avatar.addItem(item);
+
+            closetAvatar.addItem(item);
         }
 
-        return avatar;
+        return closetAvatar;
     }
 
     // 중복 아바타 검증


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #11

---

## 📝 작업 내용

ClosetAvatarSaveRequestDto(프론트엔드 요청)에서 avatarImage 제외하고 repository에서 찾는 로직으로 변경하였습니다.
