### PR TITLE
fix: 회원가입시 잘못 참조되던 프로필 이미지 변경

### DIFF
--- a/src/main/java/com/tryiton/core/auth/oauth/service/AuthService.java
+++ b/src/main/java/com/tryiton/core/auth/oauth/service/AuthService.java
@@ -179,7 +179,7 @@ public class AuthService {
             Long userId = savedMember.getId();
 
             // ★ 2. S3 이미지 처리 로직을 먼저 호출하여 새로운 URL을 확보합니다.
-            String newProfileImageUrl = handleProfileImage(dto.getUserBaseImageUrl(), userId);  //Todo: 이부분 temp -> User로 옮겨야함 (S3)
+//            String newProfileImageUrl = handleProfileImage(dto.getUserBaseImageUrl(), userId);  //Todo: 이부분 temp -> User로 옮겨야함 (S3)
 
             // ★ 3. OauthCredentials와 Profile 엔티티를 생성합니다.
             OauthCredentials oauthCredentials = OauthCredentials.builder()
@@ -196,7 +196,7 @@ public class AuthService {
                 .height(dto.getHeight())
                 .weight(dto.getWeight())
                 .shoeSize(dto.getShoeSize())
-                .profileImageUrl(newProfileImageUrl) // ★ 4. 새로 받은 URL을 사용합니다.
+                .profileImageUrl(googleInfo.getPictureUrl())
                 .userBaseImageUrl(dto.getUserBaseImageUrl())
                 .avatarBaseImageUrl(dto.getAvatarBaseImageUrl())
                 .member(savedMember)


### PR DESCRIPTION
현재 구글 회원가입시 유저에게 입력받은 전신사진(user_base_img_url)로 잘못 참조되고있어,
구글로부터 받아온 프로필 이미지로 설정되도록 변경하였습니다.