### PR TITLE
[refactor] 옷장에 아바타를 추가하는 기능의 서비스 로직 수정

### DIFF
--- a/src/main/java/com/tryiton/core/closet/controller/ClosetAvatarController.java
+++ b/src/main/java/com/tryiton/core/closet/controller/ClosetAvatarController.java
@@ -2,19 +2,16 @@ package com.tryiton.core.closet.controller;
 
 import com.tryiton.core.auth.security.CustomUserDetails;
 import com.tryiton.core.closet.dto.ClosetAvatarResponseDto;
-import com.tryiton.core.closet.dto.ClosetAvatarSaveRequestDto;
 import com.tryiton.core.closet.service.ClosetAvatarService;
 import com.tryiton.core.member.entity.Member;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,11 +34,9 @@ public class ClosetAvatarController {
 
     // 아바타 착장 저장
     @PostMapping
-    public ResponseEntity<Boolean> saveClosetAvatar(
-        @AuthenticationPrincipal CustomUserDetails userDetails,
-        @RequestBody ClosetAvatarSaveRequestDto requestDto) {
+    public ResponseEntity<Boolean> saveClosetAvatar(@AuthenticationPrincipal CustomUserDetails userDetails) {
         Member member = userDetails.getUser();
-        closetAvatarService.saveClosetAvatar(member, requestDto);
+        closetAvatarService.saveClosetAvatar(member);
         return ResponseEntity.ok(true);
 //        return ResponseEntity.status(HttpStatus.CREATED).build(); // 201 Created
     }

--- a/src/main/java/com/tryiton/core/closet/service/ClosetAvatarService.java
+++ b/src/main/java/com/tryiton/core/closet/service/ClosetAvatarService.java
@@ -4,7 +4,6 @@ import com.tryiton.core.avatar.entity.Avatar;
 import com.tryiton.core.avatar.entity.AvatarItem;
 import com.tryiton.core.avatar.repository.AvatarRepository;
 import com.tryiton.core.closet.dto.ClosetAvatarResponseDto;
-import com.tryiton.core.closet.dto.ClosetAvatarSaveRequestDto;
 import com.tryiton.core.closet.entity.ClosetAvatar;
 import com.tryiton.core.closet.entity.ClosetAvatarItem;
 import com.tryiton.core.closet.repository.ClosetAvatarRepository;
@@ -38,12 +37,12 @@ public class ClosetAvatarService {
 
     // 착장 저장
     @Transactional
-    public void saveClosetAvatar(Member user, ClosetAvatarSaveRequestDto requestDto) {
+    public void saveClosetAvatar(Member user) {
         // 최대 10개 제한 확인
         validateMaxAvatarLimit(user.getId());
         
         // 새로운 아바타 생성
-        ClosetAvatar newAvatar = createClosetAvatar(user, requestDto);
+        ClosetAvatar newAvatar = createClosetAvatar(user);
         
         // 중복 확인
         validateDuplicateAvatar(user.getId(), newAvatar);
@@ -70,8 +69,11 @@ public class ClosetAvatarService {
     }
 
     // 새로운 ClosetAvatar 생성
-    private ClosetAvatar createClosetAvatar(Member user, ClosetAvatarSaveRequestDto requestDto) {
+    private ClosetAvatar createClosetAvatar(Member user) {
         Avatar avatar = avatarRepository.findTopByMemberIdOrderByCreatedAtDesc(user.getId());
+        if (avatar == null) {
+            throw new BusinessException(HttpStatus.NOT_FOUND, "사용자의 아바타를 찾을 수 없습니다.");
+        }
 
         ClosetAvatar closetAvatar = ClosetAvatar.builder()
             .user(user)

--- a/src/test/java/com/tryiton/core/closet/service/ClosetAvatarServiceTest.java
+++ b/src/test/java/com/tryiton/core/closet/service/ClosetAvatarServiceTest.java
@@ -13,6 +13,7 @@ import com.tryiton.core.product.entity.Product;
 import com.tryiton.core.product.repository.ProductRepository;
 import com.tryiton.core.avatar.repository.AvatarRepository;
 import com.tryiton.core.avatar.entity.Avatar;
+import com.tryiton.core.avatar.entity.AvatarItem;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -73,60 +74,112 @@ class ClosetAvatarServiceTest {
     @DisplayName("착장 저장 성공")
     void saveClosetAvatar_Success() {
         // given
-        ClosetAvatarSaveRequestDto requestDto = createAvatarSaveRequest("avatar.jpg", 101L, 102L);
+        Avatar mockAvatar = createMockAvatarWithItems("avatar.jpg", product1, product2);
 
         given(closetAvatarRepository.countByUserId(user.getId())).willReturn(0L);
         given(closetAvatarRepository.findWithItemsByUserId(user.getId())).willReturn(Collections.emptyList());
-        given(avatarRepository.findTopByMemberIdOrderByCreatedAtDesc(user.getId())).willReturn(Avatar.builder().avatarImg("avatar.jpg").build());
+        given(avatarRepository.findTopByMemberIdOrderByCreatedAtDesc(user.getId())).willReturn(mockAvatar);
         given(productRepository.findByIdWithCategory(101L)).willReturn(Optional.of(product1));
         given(productRepository.findByIdWithCategory(102L)).willReturn(Optional.of(product2));
 
         // when
-        closetAvatarService.saveClosetAvatar(user, requestDto);
+        closetAvatarService.saveClosetAvatar(user);
 
         // then
         verify(closetAvatarRepository, times(1)).save(any(ClosetAvatar.class));
     }
 
-//    @Test
-//    @DisplayName("착장 저장 실패 - 10개 초과")
-//    void saveClosetAvatar_Fail_MaxLimitExceeded() {
-//        // given
-//        ClosetAvatarSaveRequestDto requestDto = createSaveRequest("avatar.jpg", 101L);
-//        given(closetAvatarRepository.countByUserId(user.getId())).willReturn(10L);
-//        given(avatarRepository.findTopByMemberIdOrderByCreatedAtDesc(user.getId())).willReturn(Avatar.builder().avatarImg("avatar.jpg").build());
-//        given(productRepository.findByIdWithCategory(101L)).willReturn(Optional.of(product1));
-//
-//        // when & then
-//        BusinessException exception = assertThrows(BusinessException.class, () -> {
-//            closetAvatarService.saveClosetAvatar(user, requestDto);
-//        });
-//
-//        assertThat(exception.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
-//        assertThat(exception.getMessage()).isEqualTo("최대 10개의 착장만 저장할 수 있습니다.");
-//        verify(closetAvatarRepository, never()).save(any(ClosetAvatar.class));
-//    }
+    @Test
+    @DisplayName("착장 저장 실패 - Avatar 없음")
+    void saveClosetAvatar_Fail_AvatarNotFound() {
+        // given
+        given(closetAvatarRepository.countByUserId(user.getId())).willReturn(0L);
+        given(avatarRepository.findTopByMemberIdOrderByCreatedAtDesc(user.getId())).willReturn(null);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            closetAvatarService.saveClosetAvatar(user);
+        });
+
+        assertThat(exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(exception.getMessage()).isEqualTo("사용자의 아바타를 찾을 수 없습니다.");
+        verify(closetAvatarRepository, never()).save(any(ClosetAvatar.class));
+    }
+
+    @Test
+    @DisplayName("착장 저장 실패 - 아바타에 아이템 없음")
+    void saveClosetAvatar_Fail_NoAvatarItems() {
+        // given
+        Avatar mockAvatar = Avatar.builder().avatarImg("avatar.jpg").build(); // items 없음
+        
+        given(closetAvatarRepository.countByUserId(user.getId())).willReturn(0L);
+        given(avatarRepository.findTopByMemberIdOrderByCreatedAtDesc(user.getId())).willReturn(mockAvatar);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            closetAvatarService.saveClosetAvatar(user);
+        });
+
+        assertThat(exception.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("아바타에 착용된 아이템이 없습니다.");
+        verify(closetAvatarRepository, never()).save(any(ClosetAvatar.class));
+    }
+
+    @Test
+    @DisplayName("착장 저장 실패 - 상품 없음")
+    void saveClosetAvatar_Fail_ProductNotFound() {
+        // given
+        Product nonExistentProduct = Product.builder().id(999L).productName("존재하지 않는 상품").build();
+        Avatar mockAvatar = createMockAvatarWithItems("avatar.jpg", nonExistentProduct);
+        
+        given(closetAvatarRepository.countByUserId(user.getId())).willReturn(0L);
+        given(closetAvatarRepository.findWithItemsByUserId(user.getId())).willReturn(Collections.emptyList());
+        given(avatarRepository.findTopByMemberIdOrderByCreatedAtDesc(user.getId())).willReturn(mockAvatar);
+        given(productRepository.findByIdWithCategory(999L)).willReturn(Optional.empty());
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            closetAvatarService.saveClosetAvatar(user);
+        });
+
+        assertThat(exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(exception.getMessage()).isEqualTo("상품을 찾을 수 없습니다. ID: 999");
+        verify(closetAvatarRepository, never()).save(any(ClosetAvatar.class));
+    }
+
+    @Test
+    @DisplayName("착장 저장 실패 - 10개 초과")
+    void saveClosetAvatar_Fail_MaxLimitExceeded() {
+        // given
+        given(closetAvatarRepository.countByUserId(user.getId())).willReturn(10L);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            closetAvatarService.saveClosetAvatar(user);
+        });
+
+        assertThat(exception.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("최대 10개의 착장만 저장할 수 있습니다.");
+        verify(closetAvatarRepository, never()).save(any(ClosetAvatar.class));
+        verify(avatarRepository, never()).findTopByMemberIdOrderByCreatedAtDesc(any());
+    }
 
     @Test
     @DisplayName("착장 저장 실패 - 중복된 착장")
     void saveClosetAvatar_Fail_DuplicateCombination() {
         // given
-        ClosetAvatarSaveRequestDto requestDto = createAvatarSaveRequest("new_avatar.jpg", 101L, 102L);
         ClosetAvatar existingAvatar = createAvatarClosetAvatar(user, "old_avatar.jpg", product1, product2);
+        Avatar mockAvatar = createMockAvatarWithItems("new_avatar.jpg", product1, product2); // 같은 상품 조합
 
         given(closetAvatarRepository.countByUserId(user.getId())).willReturn(1L);
         given(closetAvatarRepository.findWithItemsByUserId(user.getId())).willReturn(List.of(existingAvatar));
-        given(avatarRepository.findTopByMemberIdOrderByCreatedAtDesc(user.getId())).willReturn(Avatar.builder().avatarImg("new_avatar.jpg").build());
+        given(avatarRepository.findTopByMemberIdOrderByCreatedAtDesc(user.getId())).willReturn(mockAvatar);
         given(productRepository.findByIdWithCategory(101L)).willReturn(Optional.of(product1));
         given(productRepository.findByIdWithCategory(102L)).willReturn(Optional.of(product2));
-        given(avatarRepository.findTopByMemberIdOrderByCreatedAtDesc(user.getId())).willReturn(Avatar.builder().avatarImg("new_avatar.jpg").build());
-        given(productRepository.findByIdWithCategory(101L)).willReturn(Optional.of(product1));
-        given(productRepository.findByIdWithCategory(102L)).willReturn(Optional.of(product2));
-
 
         // when & then
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            closetAvatarService.saveClosetAvatar(user, requestDto);
+            closetAvatarService.saveClosetAvatar(user);
         });
 
         assertThat(exception.getStatus()).isEqualTo(HttpStatus.CONFLICT);
@@ -189,7 +242,7 @@ class ClosetAvatarServiceTest {
     private ClosetAvatarSaveRequestDto createAvatarSaveRequest(String avatarImage, Long... productIds) {
         ClosetAvatarSaveRequestDto requestDto = new ClosetAvatarSaveRequestDto();
 
-        List<ClosetAvatarItemRequestDto> items = Arrays.stream(productIds) // 이 부분을 수정했습니다.
+        List<ClosetAvatarItemRequestDto> items = Arrays.stream(productIds)
             .map(this::createAvatarItemRequest)
             .collect(Collectors.toList());
 
@@ -215,6 +268,24 @@ class ClosetAvatarServiceTest {
             ClosetAvatarItem item = ClosetAvatarItem.builder().product(product).build();
             avatar.addItem(item);
         }
+        return avatar;
+    }
+
+    // Avatar with AvatarItems를 생성하는 헬퍼 메서드
+    private Avatar createMockAvatarWithItems(String avatarImg, Product... products) {
+        Avatar avatar = Avatar.builder()
+            .avatarImg(avatarImg)
+            .build();
+        
+        List<AvatarItem> avatarItems = Arrays.stream(products)
+            .map(product -> AvatarItem.builder()
+                .product(product)
+                .build())
+            .collect(Collectors.toList());
+        
+        // ReflectionTestUtils를 사용해 items 필드에 값을 주입
+        org.springframework.test.util.ReflectionTestUtils.setField(avatar, "items", avatarItems);
+        
         return avatar;
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #11

---

## 📝 작업 내용

기존, 클라이언트로부터 옷장에 저장하는 아바타 정보를 받아왔으나,
아바타 설계가 변경된 이후 현 시점에는 렌더링 되는 아바타가 단일하기 때문에 Member 엔티티로부터 아바타를 참조하도록 수정하였습니다.
