### PR TITLE
Feat: Redis 캐싱 전략 구현 #109

### DIFF
--- a/src/main/java/com/tryiton/core/CoreApplication.java
+++ b/src/main/java/com/tryiton/core/CoreApplication.java
@@ -5,8 +5,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
+import org.springframework.scheduling.annotation.EnableScheduling;
+
 @EnableJpaAuditing //BaseTimeEntity
 @EnableAsync
+@EnableScheduling
 @SpringBootApplication
 public class CoreApplication {
 

--- a/src/main/java/com/tryiton/core/config/CacheConfig.java
+++ b/src/main/java/com/tryiton/core/config/CacheConfig.java
@@ -1,0 +1,39 @@
+package com.tryiton.core.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        // 기본 캐시 설정: 10분 TTL, JSON 직렬화
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        // 캐시 그룹별 특별 설정
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+        cacheConfigurations.put("productDetail", defaultConfig.entryTtl(Duration.ofMinutes(10))); // 상품 상세 정보는 10분
+        cacheConfigurations.put("productList", defaultConfig.entryTtl(Duration.ofMinutes(5)));   // 상품 목록은 5분
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();
+    }
+}

--- a/src/main/java/com/tryiton/core/product/service/ProductService.java
+++ b/src/main/java/com/tryiton/core/product/service/ProductService.java
@@ -27,6 +27,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.scheduling.annotation.Scheduled;
+
 /* 나이대 별 인기 상품 구현 해야함!! */
 import java.util.*;
 import java.util.stream.Collectors;
@@ -42,6 +44,20 @@ public class ProductService {
     private final CategoryRepository categoryRepository;
 
     private final RecommendBehaviorLogService recommendBehaviorLogService;
+
+    @org.springframework.cache.annotation.CacheEvict(value = "productDetail", key = "#product.id + \"_\" + '*' ")
+    @Transactional
+    public void updateProduct(Product product) {
+        productRepository.save(product);
+    }
+
+    @Scheduled(fixedRate = 3600000)// 1시간마다 실행
+    @org.springframework.cache.annotation.CacheEvict(value = "productList", allEntries = true)
+    public void clearProductListCache() {
+        // log.info("상품 목록 캐시 초기화");
+    }
+
+
 
     public List<ProductResponseDto> getPersonalizedRecommendations(Long userId) {
         List<TagScoreDto> favoriteTags = tagRepository.findUserFavoriteTags(userId);
@@ -157,6 +173,7 @@ public class ProductService {
 
     // 상품 상세 조회 (로그인/비로그인 모두 지원)
     @Transactional(readOnly = true)
+    @org.springframework.cache.annotation.Cacheable(value = "productDetail", key = "#productId + '_' + (#userId != null ? #userId : 'guest')")
     public ProductDetailResponseDto getProductDetail(Long userId, Long productId) {
         // N+1 쿼리 해결: 상품과 카테고리, variants를 함께 조회
         Product product = productRepository.findByIdWithCategoryAndVariants(productId)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #109 

---

## 📝 작업 내용

   1. Redis Cache Manager 설정 (`CacheConfig.java`)
       * @EnableCaching 어노테ATION을 통해 Spring의 캐싱 기능을 활성화했습니다.
       * RedisCacheManager Bean을 설정하여 캐시의 기본 TTL(Time-To-Live), 데이터 직렬화 방식(JSON) 등을 구성했습니다.
       * productDetail 캐시 그룹은 10분, productList 캐시 그룹은 5분의 유효시간을 갖도록 설정했습니다.


   2. 상품 상세 조회 캐싱 적용 (`ProductService.java`)
       * getProductDetail 메소드에 @Cacheable 어노테이션을 추가했습니다.
       * key는 productId와 userId를 조합하여 생성되므로, 사용자별 '찜하기' 상태가 다르더라도 정확한 데이터가 캐싱되고 반환됩니다. (e.g.,
         productDetail::10_1, productDetail::10_guest)


   3. 캐시 무효화 전략 구현 (`ProductService.java`)
       * 향후 상품 정보가 수정될 때를 대비하여, @CacheEvict를 사용해 특정 상품의 캐시를 모든 사용자(*)에 대해 무효화하는 updateProduct 메소드
         예시를 추가했습니다.
       * @Scheduled와 @CacheEvict를 사용하여 1시간마다 상품 목록 관련 캐시(productList) 전체를 비우는 clearProductListCache 메소드를
         추가했습니다.

   4. 스케줄링 활성화 (`CoreApplication.java`)
       * 주기적인 캐시 무효화를 위해 @EnableScheduling 어노테이션을 추가했습니다.