### PR TITLE
Fix: Redis 역직렬화 문제 해결 (DTO 기본 생성자 추가) #109

### DIFF
--- a/src/main/java/com/tryiton/core/product/dto/ProductDetailResponseDto.java
+++ b/src/main/java/com/tryiton/core/product/dto/ProductDetailResponseDto.java
@@ -5,8 +5,10 @@ import com.tryiton.core.product.entity.Product;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ProductDetailResponseDto {
 
     private final Long id;

--- a/src/main/java/com/tryiton/core/product/dto/ProductResponseDto.java
+++ b/src/main/java/com/tryiton/core/product/dto/ProductResponseDto.java
@@ -3,8 +3,10 @@ package com.tryiton.core.product.dto;
 import com.tryiton.core.product.entity.Product;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ProductResponseDto {
 
     private final Long id;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #109 , #111 

  Redis 캐싱 적용 후 TPS가 오히려 저하되는 문제가 발생했습니다. 로그 분석 결과, Redis에서 캐시된 데이터를 역직렬화하는 과정에서 오류가
  반복적으로 발생하고 있었으며, 이는 DTO에 기본 생성자가 없어 Jackson 라이브러리가 객체를 제대로 생성하지 못했기 때문으로 파악되었습니다.

  이 PR은 해당 문제를 해결하여 캐싱의 효율성을 높이고 TPS 저하를 방지합니다.

---

## 📝 작업 내용

### 주요 변경 사항

   1. `ProductDetailResponseDto.java` 수정
       * @NoArgsConstructor 어노테이션을 추가하여 Jackson이 역직렬화 시 사용할 기본 생성자를 명시적으로 생성하도록 했습니다.

   2. `ProductResponseDto.java` 수정
       * 마찬가지로 @NoArgsConstructor 어노테이션을 추가하여 기본 생성자를 생성하도록 했습니다.

### 문제 해결 과정

   * 문제 발생: Redis 캐싱 적용 후 TPS 저하 및 GenericJackson2JsonRedisSerializer.deserialize 관련 로그 오류 발생.
   * 원인 분석: Jackson 라이브러리가 객체를 역직렬화할 때 기본 생성자를 필요로 하지만, 해당 DTO들에 기본 생성자가 없었음. 이로 인해 역직렬화 실패
     및 불필요한 오버헤드 발생.
   * 해결: @NoArgsConstructor 어노테이션 추가를 통해 기본 생성자를 제공하여 역직렬화 문제를 해결.