### PR TITLE
Fix: DTO final 필드 제거로 Redis 역직렬화 오류 해결 #109

### DIFF
--- a/src/main/java/com/tryiton/core/product/dto/ProductDetailResponseDto.java
+++ b/src/main/java/com/tryiton/core/product/dto/ProductDetailResponseDto.java
@@ -11,17 +11,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ProductDetailResponseDto {
 
-    private final Long id;
-    private final String productName;
-    private final String brand;
-    private final int price; // 정가
-    private final int sale; // 할인율 (%)
-    private final int salePrice; // 할인된 가격
-    private final String content;
-    private final List<String> images;
-    private final int wishlistCount;
-    private final List<ProductVariantDto> variant;
-    private final boolean liked; // 찜 여부 추가
+    private Long id;
+    private String productName;
+    private String brand;
+    private int price; // 정가
+    private int sale; // 할인율 (%)
+    private int salePrice; // 할인된 가격
+    private String content;
+    private List<String> images;
+    private int wishlistCount;
+    private List<ProductVariantDto> variant;
+    private boolean liked; // 찜 여부 추가
 
     public ProductDetailResponseDto(Product product, List<ProductVariantDto> variant, boolean liked) {
         this.id = product.getId();

--- a/src/main/java/com/tryiton/core/product/dto/ProductResponseDto.java
+++ b/src/main/java/com/tryiton/core/product/dto/ProductResponseDto.java
@@ -9,18 +9,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ProductResponseDto {
 
-    private final Long id;
-    private final String productName;
-    private final String img1;
-    private final int price; // 정가
-    private final int sale; // 할인율 (%)
-    private final int salePrice; // 할인된 가격
-    private final boolean liked; // 유저가 찜한 상품인지 여부
-    private final String brand;
-    private final int wishlistCount;
-    private final LocalDateTime createdAt;
-    private final Long categoryId;
-    private final String categoryName;
+    private Long id;
+    private String productName;
+    private String img1;
+    private int price; // 정가
+    private int sale; // 할인율 (%)
+    private int salePrice; // 할인된 가격
+    private boolean liked; // 유저가 찜한 상품인지 여부
+    private String brand;
+    private int wishlistCount;
+    private LocalDateTime createdAt;
+    private Long categoryId;
+    private String categoryName;
 
     public ProductResponseDto(Product product, boolean liked) {
         this.id = product.getId();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #111 #114 

---

## 📝 작업 내용


  주요 변경 사항


   1. `ProductDetailResponseDto.java` 수정
       * 모든 필드에서 final 키워드를 제거했습니다.

   2. `ProductResponseDto.java` 수정
       * 모든 필드에서 final 키워드를 제거했습니다.

  문제 해결 과정


   * 문제 발생: Redis 캐싱 적용 후 TPS 저하 및 GenericJackson2JsonRedisSerializer.deserialize 오류.
   * 원인 분석: DTO 필드에 final 키워드가 있어 @NoArgsConstructor로 생성된 기본 생성자가 해당 필드들을 초기화할 수 없었음. 이로 인해 Jackson의
     역직렬화 실패.
   * 해결: final 키워드 제거를 통해 Jackson이 필드에 값을 할당할 수 있도록 허용.