### PR TITLE
[fix] 메인페이지, 카테고리별 페이지 쿼리 수정

### DIFF
--- a/src/main/java/com/tryiton/core/product/controller/ProductController.java
+++ b/src/main/java/com/tryiton/core/product/controller/ProductController.java
@@ -1,9 +1,7 @@
 package com.tryiton.core.product.controller;
 
 import com.tryiton.core.auth.security.CustomUserDetails;
-import com.tryiton.core.avatar.service.AvatarService;
 import com.tryiton.core.product.dto.CategoryProductResponse;
-import com.tryiton.core.product.dto.MainProductResponse;
 import com.tryiton.core.product.dto.ProductResponseDto;
 import com.tryiton.core.product.dto.SearchProductResponse;
 import com.tryiton.core.product.entity.Category;
@@ -23,24 +21,6 @@ public class ProductController {
 
     private final ProductService productService;
     private final CategoryService categoryService;
-    private final AvatarService avatarService;
-
-    @GetMapping
-    public ResponseEntity<MainProductResponse> getMainProducts(
-        @AuthenticationPrincipal() CustomUserDetails customUserDetails
-    ) {
-        // 인증된 사용자만 접근 가능 (기존 로직 유지)
-        Long userId = customUserDetails.getUser().getId();
-
-        List<ProductResponseDto> recommended = productService.getPersonalizedRecommendations(
-            userId);
-        List<ProductResponseDto> ranked = productService.getTopRankedProducts(userId);
-
-        return ResponseEntity.ok(MainProductResponse.builder()
-            .recommended(recommended)
-            .ranked(ranked)
-            .build());
-    }
 
     @GetMapping("/category")
     public ResponseEntity<CategoryProductResponse> getCategoryProducts(

--- a/src/main/java/com/tryiton/core/product/repository/ProductRepository.java
+++ b/src/main/java/com/tryiton/core/product/repository/ProductRepository.java
@@ -91,12 +91,18 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
         String productName, String brand, Pageable pageable
     );
 
-    // 각 카테고리별 상위 8개 상품 조회 (LIMIT 추가로 성능 최적화)
+    // 각 카테고리별 상위 4개 상품 조회
     @Query(value = """
-            SELECT p.* FROM product p
-            WHERE p.deleted = false
-            ORDER BY p.category_id, p.wishlist_count DESC, p.create_at DESC
-            LIMIT 200
+            WITH RankedProducts AS (
+                SELECT p.*,
+                       ROW_NUMBER() OVER (PARTITION BY p.category_id
+                                        ORDER BY p.wishlist_count DESC, p.create_at DESC) as rn
+                FROM product p
+                WHERE p.deleted = false
+            )
+            SELECT * FROM RankedProducts
+            WHERE rn <= 4
+            ORDER BY category_id, wishlist_count DESC, create_at DESC
             """, nativeQuery = true)
-    List<Product> findTop8ProductsPerCategoryWithCategory();
+    List<Product> findTop4ProductsPerCategory();
 }

--- a/src/main/java/com/tryiton/core/product/service/ProductService.java
+++ b/src/main/java/com/tryiton/core/product/service/ProductService.java
@@ -96,8 +96,7 @@ public class ProductService {
             .toList();
     }
 
-    public Page<ProductResponseDto> getProductsByCategory(Long userId, Category category, int page,
-        int size) {
+    public Page<ProductResponseDto> getProductsByCategory(Long userId, Category category, int page, int size) {
         // wishlistCount 기준으로 내림차순 정렬
         Pageable pageable = PageRequest.of(page, size, Sort.by("wishlistCount").descending().and(Sort.by("createAt").descending()));
 
@@ -111,25 +110,7 @@ public class ProductService {
         return productRepository.findByCategoryHierarchyAndDeletedFalse(category.getId(), pageable)
             .map(product -> new ProductResponseDto(product,
                 likedProductIds.contains(product.getId())));
-        }
-
-        /*
-
-        // 페이지네이션을 유지하면서 매번 다른 순서로 보여주기 위한 시드 생성
-        // 사용자별 + 시간 기반으로 시드 생성하여 일정 시간 동안은 같은 순서 유지
-        int seed = generateRandomSeed(userId);
-
-        Pageable pageable = PageRequest.of(page, size);
-        Set<Long> likedProductIds = new HashSet<>();
-
-        if (userId != null) {
-            likedProductIds.addAll(wishlistRepository.findProductIdsByUserId(userId));
-        }
-
-        return productRepository.findRandomByCategoryWithSeed(category.getId(), seed, pageable)
-            .map(product -> new ProductResponseDto(product, likedProductIds.contains(product.getId())));
-         */
-
+    }
 
     // 상품 상세 조회 (로그인/비로그인 모두 지원)
     @Transactional(readOnly = true)
@@ -162,7 +143,7 @@ public class ProductService {
     // 비로그인 사용자용 메인 페이지 상품 조회
     public MainProductGuestResponse getMainPageProductsForGuest() {
         // 모든 카테고리 조회
-        List<Product> allProducts = productRepository.findTop8ProductsPerCategoryWithCategory();
+        List<Product> allProducts = productRepository.findTop4ProductsPerCategory();
 
         Map<Category, List<Product>> productsByCategory = allProducts.stream()
                 .collect(Collectors.groupingBy(Product::getCategory));

--- a/src/main/java/com/tryiton/core/product/service/ProductService.java
+++ b/src/main/java/com/tryiton/core/product/service/ProductService.java
@@ -98,9 +98,8 @@ public class ProductService {
 
     public Page<ProductResponseDto> getProductsByCategory(Long userId, Category category, int page,
         int size) {
-        // 기존 생성일 기준 정렬
-        /*
-        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        // wishlistCount 기준으로 내림차순 정렬
+        Pageable pageable = PageRequest.of(page, size, Sort.by("wishlistCount").descending().and(Sort.by("createAt").descending()));
 
         Set<Long> likedProductIds = new HashSet<>();
 
@@ -114,17 +113,12 @@ public class ProductService {
                 likedProductIds.contains(product.getId())));
         }
 
-        private void collectAllSubCategories(Category category, List<Category> categoryList) {
-            categoryList.add(category);
-            for (Category child : category.getChildren()) {
-                collectAllSubCategories(child, categoryList);
-        }
-         */
+        /*
 
         // 페이지네이션을 유지하면서 매번 다른 순서로 보여주기 위한 시드 생성
         // 사용자별 + 시간 기반으로 시드 생성하여 일정 시간 동안은 같은 순서 유지
         int seed = generateRandomSeed(userId);
-        
+
         Pageable pageable = PageRequest.of(page, size);
         Set<Long> likedProductIds = new HashSet<>();
 
@@ -134,26 +128,8 @@ public class ProductService {
 
         return productRepository.findRandomByCategoryWithSeed(category.getId(), seed, pageable)
             .map(product -> new ProductResponseDto(product, likedProductIds.contains(product.getId())));
-    }
+         */
 
-    // 사용자별 + 시간 기반 시드 생성 (10분마다 변경)
-    private int generateRandomSeed(Long userId) {
-        long currentTime = System.currentTimeMillis();
-        long timeWindow = currentTime / (10 * 60 * 1000); // 10분 단위
-        
-        if (userId != null) {
-            return (int) ((userId + timeWindow) % Integer.MAX_VALUE);
-        } else {
-            return (int) (timeWindow % Integer.MAX_VALUE);
-        }
-    }
-
-    private void collectAllSubCategories(Category category, List<Category> categoryList) {
-        categoryList.add(category);
-        for (Category child : category.getChildren()) {
-            collectAllSubCategories(child, categoryList);
-        }
-    }
 
     // 상품 상세 조회 (로그인/비로그인 모두 지원)
     @Transactional(readOnly = true)
@@ -165,8 +141,9 @@ public class ProductService {
 
         // 비로그인 사용자인 경우 찜 상태는 false로 처리
         boolean liked = false;
+
         if (userId != null) {
-            liked = wishlistRepository.findProductIdsByUserId(userId).contains(productId);
+            liked = wishlistRepository.existsByUserIdAndProductId(userId, productId);
         }
 
         // 이미 fetch join으로 variants가 로딩되어 추가 쿼리 없음


### PR DESCRIPTION


## 📝 작업 내용

1. 카테고리별 상품 조회를 인기순으로 변경했습니다.
2. 비회원 메인페이지에 노출되는 상품을 카테고리별 상위 4개로 변경하였습니다.