### PR TITLE
Feat: 캐싱 전용 Redis 설정 분리 #109

### DIFF
--- a/src/main/java/com/tryiton/core/config/CacheConfig.java
+++ b/src/main/java/com/tryiton/core/config/CacheConfig.java
@@ -1,5 +1,6 @@
 package com.tryiton.core.config;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,7 +20,7 @@ import java.util.Map;
 public class CacheConfig {
 
     @Bean
-    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+    public RedisCacheManager cacheManager(@Qualifier("cacheRedisConnectionFactory") RedisConnectionFactory connectionFactory) {
         // 기본 캐시 설정: 10분 TTL, JSON 직렬화
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofMinutes(10))

--- a/src/main/java/com/tryiton/core/config/CacheRedisConfig.java
+++ b/src/main/java/com/tryiton/core/config/CacheRedisConfig.java
@@ -1,0 +1,61 @@
+package com.tryiton.core.config;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.SslOptions;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class CacheRedisConfig {
+
+    @Value("${cache.redis.host}")
+    private String cacheRedisHost;
+
+    @Value("${cache.redis.port}")
+    private int cacheRedisPort;
+
+    @Bean(name = "cacheRedisConnectionFactory")
+    public RedisConnectionFactory cacheRedisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(cacheRedisHost, cacheRedisPort);
+
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+            .commandTimeout(Duration.ofSeconds(60))
+            .clientOptions(ClientOptions.builder()
+                .socketOptions(SocketOptions.builder()
+                    .connectTimeout(Duration.ofSeconds(60))
+                    .build())
+                .sslOptions(SslOptions.builder()
+                    .protocols("TLSv1.2")
+                    .jdkSslProvider()
+                    .build())
+                .build())
+            .useSsl()
+            .build();
+
+        return new LettuceConnectionFactory(redisConfig, clientConfig);
+    }
+
+    @Bean(name = "cacheRedisTemplate")
+    public RedisTemplate<String, Object> cacheRedisTemplate(@Qualifier("cacheRedisConnectionFactory") RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+        
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/tryiton/core/product/service/ProductService.java
+++ b/src/main/java/com/tryiton/core/product/service/ProductService.java
@@ -112,6 +112,7 @@ public class ProductService {
                 .toList();
     }
 
+    @org.springframework.cache.annotation.Cacheable(value = "categoryProducts", key = "#category.id + '_' + #page + '_' + #size + '_' + (#userId != null ? #userId : 'guest')")
     public Page<ProductResponseDto> getProductsByCategory(Long userId, Category category, int page, int size) {
         // wishlistCount 기준으로 내림차순 정렬
         Pageable pageable = PageRequest.of(page, size, Sort.by("wishlistCount").descending().and(Sort.by("createAt").descending()));

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -29,9 +29,18 @@ spring.data.redis.lettuce.shutdown-timeout=60000
 # Lettuce
 spring.data.redis.lettuce.cluster.verify-hostname=false
 
+spring.data.redis.lettuce.pool.max-active=8
+spring.data.redis.lettuce.pool.max-idle=8
+spring.data.redis.lettuce.pool.min-idle=2
+spring.data.redis.lettuce.pool.max-wait=-1ms
+
 # Cache Redis Configuration
 cache.redis.host=${CACHE_REDIS_URL}
 cache.redis.port=6379
+cache.redis.lettuce.pool.max-active=8
+cache.redis.lettuce.pool.max-idle=8
+cache.redis.lettuce.pool.min-idle=2
+cache.redis.lettuce.pool.max-wait=-1ms
 
 # Redis logging
 logging.level.org.springframework.data.redis=DEBUG

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -29,6 +29,10 @@ spring.data.redis.lettuce.shutdown-timeout=60000
 # Lettuce
 spring.data.redis.lettuce.cluster.verify-hostname=false
 
+# Cache Redis Configuration
+cache.redis.host=${CACHE_REDIS_URL}
+cache.redis.port=6379
+
 # Redis logging
 logging.level.org.springframework.data.redis=DEBUG
 logging.level.io.lettuce.core=DEBUG


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #116 #111 #114 
---

## 📝 작업 내용


   1. `CacheRedisConfig.java` 신규 생성
       * 캐싱만을 위한 전용 RedisConnectionFactory (cacheRedisConnectionFactory)와 RedisTemplate (cacheRedisTemplate) 빈을 정의했습니다.
       * 이 빈들은 @Qualifier 어노테이션을 통해 명시적인 이름을 부여하여 기존 Redis 빈들과의 충돌을 방지합니다.
       * 캐싱에 적합한 GenericJackson2JsonRedisSerializer를 사용하도록 설정했습니다.


   2. `CacheConfig.java` 수정
       * RedisCacheManager 빈이 CacheRedisConfig에서 정의한 cacheRedisConnectionFactory를 @Qualifier("cacheRedisConnectionFactory")를 통해
         명시적으로 주입받도록 수정했습니다. 이로써 Spring의 @Cacheable, @CacheEvict 어노테이션을 사용하는 모든 캐싱 작업은 이제 이 전용 Redis
         인스턴스를 사용하게 됩니다.


   3. `application-dev.properties` 수정
       * 캐싱 전용 Redis 서버의 호스트와 포트 정보를 위한 새로운 속성(cache.redis.host, cache.redis.port)을 추가했습니다. 이 속성들은 환경 변수
         CACHE_REDIS_URL에서 값을 가져오도록 설정됩니다.

  문제 해결 과정


   * 문제점: 기존 Redis 설정과 캐싱 Redis 설정이 혼재되어 직렬화 방식 충돌 및 TPS 저하 문제 발생.
   * 원인 분석: Spring이 어떤 RedisConnectionFactory를 캐싱에 사용해야 할지 모호했고, 기존 Redis의 StringRedisSerializer와 캐싱의
     GenericJackson2JsonRedisSerializer 간의 직렬화 방식 불일치가 역직렬화 오류의 주된 원인이었음.
   * 해결: 캐싱 전용 Redis 설정을 별도의 설정 클래스로 완전히 분리하고, @Qualifier를 통해 명시적으로 연결함으로써 문제를 해결했습니다. 기존 Redis
     설정은 그대로 유지됩니다.
