### PR TITLE
Fix: ProductVariantDto 역직렬화 오류 해결 #109

### DIFF
--- a/src/main/java/com/tryiton/core/product/dto/ProductVariantDto.java
+++ b/src/main/java/com/tryiton/core/product/dto/ProductVariantDto.java
@@ -2,14 +2,16 @@ package com.tryiton.core.product.dto;
 
 import com.tryiton.core.product.entity.ProductVariant;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ProductVariantDto {
 
-    private final Long variantId;
-    private final String size;
-    private final String color;
-    private final Integer quantity;
+    private Long variantId;
+    private String size;
+    private String color;
+    private Integer quantity;
 
     public ProductVariantDto(ProductVariant variant) {
         this.variantId = variant.getVariantId();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #109 #111 #114 #116 #120

  Redis 캐싱 적용 후 ProductDetailResponseDto를 역직렬화하는 과정에서 ProductVariantDto에 대한 SerializationException이 발생하는 문제가 있었습니다. 이는 ProductVariantDto에 기본 생성자가 없었고, 필드들이 final로 선언되어 있어 Jackson 라이브러리가 객체를 제대로 생성하고 값을 할당하지 못했기 때문


---

## 📝 작업 내용

  주요 변경 사항


   1. `ProductVariantDto.java` 수정
       * @NoArgsConstructor 어노테이션을 추가하여 Jackson이 역직렬화 시 사용할 기본 생성자를 명시적으로 생성하도록 했습니다.
       * 모든 필드(variantId, size, color, quantity)에서 final 키워드를 제거하여, 기본 생성자를 통해 필드에 값을 할당할 수 있도록 했습니다.

  문제 해결 과정


   * 문제 발생: ProductDetailResponseDto 캐시 역직렬화 시 SerializationException 발생.
   * 원인 분석: ProductDetailResponseDto 내부에 포함된 ProductVariantDto에 @NoArgsConstructor가 없었고, 필드들이 final로 선언되어 있어 Jackson이
     역직렬화에 실패.
   * 해결: ProductVariantDto에 @NoArgsConstructor를 추가하고 final 키워드를 제거하여 역직렬화 문제를 해결.