### PR TITLE
refactor: 캐시용 Redis 설정 분리 #109

### DIFF
--- a/src/main/java/com/tryiton/core/config/CacheConfig.java
+++ b/src/main/java/com/tryiton/core/config/CacheConfig.java
@@ -1,11 +1,14 @@
 package com.tryiton.core.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
@@ -16,8 +19,22 @@ import java.time.Duration;
 @Configuration
 @EnableCaching
 public class CacheConfig {
+    @Value("${cache.redis.host}")
+    private String host;
+    
+    @Value("${cache.redis.port}")
+    private int port;
+
     @Bean
-    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+    public RedisConnectionFactory cacheRedisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory cacheRedisConnectionFactory) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
             .entryTtl(Duration.ofMinutes(30))
             .serializeKeysWith(RedisSerializationContext.SerializationPair
@@ -25,15 +42,15 @@ public class CacheConfig {
             .serializeValuesWith(RedisSerializationContext.SerializationPair
                 .fromSerializer(new GenericJackson2JsonRedisSerializer()));
 
-        return RedisCacheManager.builder(redisConnectionFactory)
+        return RedisCacheManager.builder(cacheRedisConnectionFactory)
             .cacheDefaults(redisCacheConfiguration)
             .build();
     }
 
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    @Bean(name = "cacheRedisTemplate")
+    public RedisTemplate<String, Object> cacheRedisTemplate(RedisConnectionFactory cacheRedisConnectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
+        template.setConnectionFactory(cacheRedisConnectionFactory);
         
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());


### PR DESCRIPTION
- 캐시 전용 Redis 연결 설정 추가
- Redis 서버 분리 (메인/캐시)
- 캐시 관련 Bean 이름 명확화