### PR TITLE
fix: RecommendationService에 올바른 RedisTemplate 주입 (#109)

### DIFF
--- a/src/main/java/com/tryiton/core/recommend/service/RecommendationService.java
+++ b/src/main/java/com/tryiton/core/recommend/service/RecommendationService.java
@@ -31,7 +31,7 @@ public class RecommendationService {
     private final SharedDataAccessor sharedDataAccessor;
 
     public RecommendationService(
-            @Qualifier("redisTemplate") RedisTemplate<String, Object> redisTemplate,
+            @Qualifier("cacheRedisTemplate") RedisTemplate<String, Object> redisTemplate,
             ObjectMapper objectMapper,
             ProductRepository productRepository,
             WishlistRepository wishlistRepository,


### PR DESCRIPTION

  #️⃣ 연관된 이슈

  > #109

  ---

  📝 작업 내용

  > ### Redis 설정 통합 및 직렬화 문제 해결
  >
  > 기존에 두 개의 Redis 설정 파일(RedisConfig.java, CacheRedisConfig.java)로 분리되어 있던 것을 UnifiedRedisConfig.java 하나로 통합하여 관리의
  효율성을 높였습니다.
  >
  > 이 과정에서 두 개의 다른 Redis 엔드포인트(일반 데이터용, 캐시용)를 사용하면서 발생하던 직렬화/역직렬화 충돌 문제를 해결했습니다.
  >
  > 주요 변경 사항:
  >
  >    `UnifiedRedisConfig` 도입*:
  >     *   일반 문자열 데이터를 처리하는 redisTemplate (StringSerializer 사용)
  >     *   캐시 및 복합 객체(JSON)를 처리하는 cacheRedisTemplate (Jackson2JsonRedisSerializer 사용)
  >     *   두 개의 RedisConnectionFactory를 명확히 분리하여 각각의 RedisTemplate에 주입
  >
  >    의존성 주입 문제 해결*:
  >     *   RedisDataMigrator, RecommendationService 등에서 RedisTemplate<String, Object> 타입을 필요로 하는 서비스에
  @Qualifier("cacheRedisTemplate")을 명시하여, 올바른 JSON 직렬화 방식의 RedisTemplate을 주입하도록 수정했습니다.
  >     *   이를 통해 애플리케이션 시작 시 발생하던 NoSuchBeanDefinitionException 오류를 해결했습니다.
  >
  >    캐시 초기화 스크립트 수정*:
  >     *   AWS ElastiCache 환경에서 redis-cli가 정상적으로 동작하도록 --tls 옵션을 추가하는 방향으로 논의되었으나, 최종적으로는 redis-cli를
  직접 사용하는 방식으로 캐시를 초기화했습니다.

  ---

  📷 스크린샷 (선택)

  > 해당 없음

  ---

  💬 리뷰 요구사항 (선택)

  > 해당 없음

  ---
