### PR TITLE
fix: Redis 직렬화 오류 수정

### DIFF
--- a/src/main/java/com/tryiton/core/common/service/SharedDataAccessor.java
+++ b/src/main/java/com/tryiton/core/common/service/SharedDataAccessor.java
@@ -32,11 +32,7 @@ public class SharedDataAccessor {
     public void saveSharedData(String key, Object value) {
         String prefixedKey = "shared:" + key;
         try {
-            if (value instanceof String) {
-                cacheRedisTemplate.opsForValue().set(prefixedKey, value);
-            } else {
-                cacheRedisTemplate.opsForValue().set(prefixedKey, objectMapper.writeValueAsString(value));
-            }
+            cacheRedisTemplate.opsForValue().set(prefixedKey, value);
             log.debug("공유 데이터 저장 성공: {}", prefixedKey);
         } catch (Exception e) {
             log.error("공유 데이터 저장 실패: {}, 오류: {}", prefixedKey, e.getMessage(), e);
@@ -54,11 +50,7 @@ public class SharedDataAccessor {
     public void saveSharedData(String key, Object value, long timeout, TimeUnit unit) {
         String prefixedKey = "shared:" + key;
         try {
-            if (value instanceof String) {
-                cacheRedisTemplate.opsForValue().set(prefixedKey, value, timeout, unit);
-            } else {
-                cacheRedisTemplate.opsForValue().set(prefixedKey, objectMapper.writeValueAsString(value), timeout, unit);
-            }
+            cacheRedisTemplate.opsForValue().set(prefixedKey, value, timeout, unit);
             log.debug("공유 데이터 저장 성공 (TTL 설정): {}, TTL: {} {}", prefixedKey, timeout, unit);
         } catch (Exception e) {
             log.error("공유 데이터 저장 실패: {}, 오류: {}", prefixedKey, e.getMessage(), e);

--- a/src/main/java/com/tryiton/core/recommend/service/RecommendationService.java
+++ b/src/main/java/com/tryiton/core/recommend/service/RecommendationService.java
@@ -70,9 +70,8 @@ public class RecommendationService {
             if (lambdaProducts != null && !lambdaProducts.isEmpty()) {
                 log.info("트렌딩 상품 조회 데이터 존재");
                 
-                // 공유 데이터로 저장 (sharedDataAccessor는 String을 기대하므로 변환)
-                String dataToSave = objectMapper.writeValueAsString(lambdaProducts);
-                sharedDataAccessor.saveSharedData("trending", dataToSave);
+                // 공유 데이터로 저장
+                sharedDataAccessor.saveSharedData("trending", lambdaProducts);
                 
                 return convertLambdaProductsToResponseDto(lambdaProducts, userId);
             }
@@ -104,9 +103,8 @@ public class RecommendationService {
             }
             
             if (products != null && !products.isEmpty()) {
-                // 공유 데이터로 저장 (sharedDataAccessor는 String을 기대하므로 변환)
-                String dataToSave = objectMapper.writeValueAsString(products);
-                sharedDataAccessor.saveSharedData("trending", dataToSave);
+                // 공유 데이터로 저장
+                sharedDataAccessor.saveSharedData("trending", products);
                 
                 return products;
             }
@@ -143,9 +141,8 @@ public class RecommendationService {
             }
             
             if (lambdaProducts != null) {
-                // 공유 데이터로 저장 (sharedDataAccessor는 String을 기대하므로 변환)
-                String dataToSave = objectMapper.writeValueAsString(lambdaProducts);
-                sharedDataAccessor.saveSharedData(sharedKey, dataToSave);
+                // 공유 데이터로 저장
+                sharedDataAccessor.saveSharedData(sharedKey, lambdaProducts);
                 
                 return convertLambdaProductsToResponseDto(lambdaProducts, userId);
             }
@@ -181,9 +178,8 @@ public class RecommendationService {
             }
             
             if (lambdaProducts != null) {
-                // 공유 데이터로 저장 (sharedDataAccessor는 String을 기대하므로 변환)
-                String dataToSave = objectMapper.writeValueAsString(lambdaProducts);
-                sharedDataAccessor.saveSharedData(sharedKey, dataToSave);
+                // 공유 데이터로 저장
+                sharedDataAccessor.saveSharedData(sharedKey, lambdaProducts);
                 
                 return convertLambdaProductsToResponseDto(lambdaProducts, userId);
             }
@@ -219,9 +215,8 @@ public class RecommendationService {
             }
             
             if (lambdaProducts != null) {
-                // 공유 데이터로 저장 (sharedDataAccessor는 String을 기대하므로 변환)
-                String dataToSave = objectMapper.writeValueAsString(lambdaProducts);
-                sharedDataAccessor.saveSharedData(sharedKey, dataToSave);
+                // 공유 데이터로 저장
+                sharedDataAccessor.saveSharedData(sharedKey, lambdaProducts);
                 
                 return convertLambdaProductsToResponseDto(lambdaProducts, userId);
             }


### PR DESCRIPTION
Redis 데이터 저장 시 수동으로 JSON 문자열 변환을 하던 로직을 제거하고, RedisTemplate에 설정된 Jackson2JsonRedisSerializer를 사용하도록 변경하여 직렬화/역직렬화 데이터 형식 불일치 문제를 해결합니다.

- SharedDataAccessor에서 ObjectMapper를 사용한 수동 직렬화 로직 제거
- RedisTemplate이 직렬화를 처리하도록 위임

Resolves: #109