### PR TITLE
fix: Redis 직렬화 및 클라이언트 설정 오류 해결

### DIFF
--- a/src/main/java/com/tryiton/core/config/UnifiedRedisConfig.java
+++ b/src/main/java/com/tryiton/core/config/UnifiedRedisConfig.java
@@ -86,8 +86,9 @@ public class UnifiedRedisConfig implements CachingConfigurer {
     private RedisConnectionFactory createConnectionFactory(String host, int port, boolean useSsl) {
         RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(host, port);
         LettuceClientConfiguration.LettuceClientConfigurationBuilder clientConfigBuilder = LettuceClientConfiguration.builder()
-            .clientOptions(clientOptions())
-            .clientResources(clientResources());
+                .clientOptions(clientOptions())
+                .clientResources(clientResources())
+                .clientName("tryiton-client");
 
         if (useSsl) {
             clientConfigBuilder.useSsl();
@@ -129,7 +130,6 @@ public class UnifiedRedisConfig implements CachingConfigurer {
             }
         ));
         objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
-        objectMapper.activateDefaultTyping(LaissezFaireSubTypeValidator.instance, ObjectMapper.DefaultTyping.NON_FINAL);
         return objectMapper;
     }
 


### PR DESCRIPTION

  주요 변경 사항

   - Redis 직렬화 오류 해결: UnifiedRedisConfig에서 ObjectMapper의 기본 타이핑 설정을 제거하여, Redis 데이터 역직렬화 시 발생하던
     SerializationException을 해결했습니다. 이로 인해 추천 시스템의 트렌딩 상품 조회 기능이 정상적으로 작동합니다.
   - Lettuce 클라이언트 설정 수정: Lettuce 클라이언트가 AWS ElastiCache에서 지원하지 않는 CLIENT SETINFO 명령어를 보내는 문제를 해결하기 위해
     클라이언트 이름을 명시적으로 설정했습니다. 이를 통해 불필요한 오류 로그가 발생하는 것을 방지합니다.

  해결된 문제

   - 추천 상품 조회 시 SerializationException이 발생하며 애플리케이션이 비정상적으로 종료되는 문제
   - Redis 연결 시 ERR unknown subcommand 'setinfo' 오류 로그가 기록되는 문제

  영향 범위

   - com.tryiton.core.config.UnifiedRedisConfig
   - 추천 시스템 및 Redis 캐시를 사용하는 모든 기능의 안정성 향상
