### PR TITLE
fix: Redis 역직렬화 및 타입 변환 오류 해결

### DIFF
--- a/src/main/java/com/tryiton/core/common/service/SharedDataAccessor.java
+++ b/src/main/java/com/tryiton/core/common/service/SharedDataAccessor.java
@@ -1,5 +1,6 @@
 package com.tryiton.core.common.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -81,6 +82,28 @@ public class SharedDataAccessor {
                 log.debug("타입 변환 시도: {} -> {}", value.getClass().getName(), type.getName());
                 return objectMapper.convertValue(value, type);
             }
+        } catch (Exception e) {
+            log.error("공유 데이터 조회 실패: {}, 오류: {}", prefixedKey, e.getMessage(), e);
+            throw new RuntimeException("공유 데이터 조회 실패", e);
+        }
+    }
+
+    /**
+     * 제네릭 타입을 포함한 공유 데이터 조회
+     * @param key 데이터 키
+     * @param typeReference 반환 타입 참조
+     * @return 저장된 값 또는 null
+     */
+    public <T> T getSharedData(String key, TypeReference<T> typeReference) {
+        String prefixedKey = "shared:" + key;
+        try {
+            Object value = cacheRedisTemplate.opsForValue().get(prefixedKey);
+            if (value == null) {
+                log.debug("공유 데이터 없음: {}", prefixedKey);
+                return null;
+            }
+            log.debug("타입 변환 시도: {} -> {}", value.getClass().getName(), typeReference.getType());
+            return objectMapper.convertValue(value, typeReference);
         } catch (Exception e) {
             log.error("공유 데이터 조회 실패: {}, 오류: {}", prefixedKey, e.getMessage(), e);
             throw new RuntimeException("공유 데이터 조회 실패", e);

--- a/src/main/java/com/tryiton/core/config/UnifiedRedisConfig.java
+++ b/src/main/java/com/tryiton/core/config/UnifiedRedisConfig.java
@@ -75,10 +75,11 @@ public class UnifiedRedisConfig implements CachingConfigurer {
     }
 
     @Bean
-    public DefaultClientResources clientResources() {
+    public io.lettuce.core.resource.ClientResources clientResources() {
         return DefaultClientResources.builder()
             .ioThreadPoolSize(4)
             .computationThreadPoolSize(4)
+            .commandLatencyCollector(io.lettuce.core.metrics.DefaultCommandLatencyCollector.disabled())
             .build();
     }
 
@@ -120,7 +121,7 @@ public class UnifiedRedisConfig implements CachingConfigurer {
                 @Override
                 public PageImpl deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
                     JsonNode node = p.getCodec().readTree(p);
-                    List content = new ObjectMapper().readValue(node.get("content").traverse(), List.class);
+                    List content = new ObjectMapper().readValue(node.get("content").traverse(), new com.fasterxml.jackson.core.type.TypeReference<List<Object>>() {});
                     JsonNode pageableNode = node.get("pageable");
                     int number = pageableNode.get("pageNumber").asInt();
                     int size = pageableNode.get("pageSize").asInt();

--- a/src/main/java/com/tryiton/core/recommend/service/RecommendationService.java
+++ b/src/main/java/com/tryiton/core/recommend/service/RecommendationService.java
@@ -50,7 +50,7 @@ public class RecommendationService {
             // 공유 데이터 접근자를 통해 먼저 조회 시도
             if (sharedDataAccessor.hasSharedData("trending")) {
                 log.info("공유 데이터 접근자를 통해 트렌딩 상품 조회");
-                List<LambdaBatchDto> lambdaProducts = sharedDataAccessor.getSharedData("trending", List.class);
+                List<LambdaBatchDto> lambdaProducts = sharedDataAccessor.getSharedData("trending", new TypeReference<List<LambdaBatchDto>>() {});
                 if (lambdaProducts != null && !lambdaProducts.isEmpty()) {
                     return convertLambdaProductsToResponseDto(lambdaProducts, userId);
                 }
@@ -124,7 +124,7 @@ public class RecommendationService {
         try {
             // 공유 데이터 접근자를 통해 먼저 조회 시도
             if (sharedDataAccessor.hasSharedData(sharedKey)) {
-                List<LambdaBatchDto> lambdaProducts = sharedDataAccessor.getSharedData(sharedKey, List.class);
+                List<LambdaBatchDto> lambdaProducts = sharedDataAccessor.getSharedData(sharedKey, new TypeReference<List<LambdaBatchDto>>() {});
                 if (lambdaProducts != null) {
                     return convertLambdaProductsToResponseDto(lambdaProducts, userId);
                 }
@@ -161,7 +161,7 @@ public class RecommendationService {
         try {
             // 공유 데이터 접근자를 통해 먼저 조회 시도
             if (sharedDataAccessor.hasSharedData(sharedKey)) {
-                List<LambdaBatchDto> lambdaProducts = sharedDataAccessor.getSharedData(sharedKey, List.class);
+                List<LambdaBatchDto> lambdaProducts = sharedDataAccessor.getSharedData(sharedKey, new TypeReference<List<LambdaBatchDto>>() {});
                 if (lambdaProducts != null) {
                     return convertLambdaProductsToResponseDto(lambdaProducts, userId);
                 }
@@ -198,7 +198,7 @@ public class RecommendationService {
         try {
             // 공유 데이터 접근자를 통해 먼저 조회 시도
             if (sharedDataAccessor.hasSharedData(sharedKey)) {
-                List<LambdaBatchDto> lambdaProducts = sharedDataAccessor.getSharedData(sharedKey, List.class);
+                List<LambdaBatchDto> lambdaProducts = sharedDataAccessor.getSharedData(sharedKey, new TypeReference<List<LambdaBatchDto>>() {});
                 if (lambdaProducts != null) {
                     return convertLambdaProductsToResponseDto(lambdaProducts, userId);
                 }


### PR DESCRIPTION

  주요 변경 사항

   - Redis `ClassCastException` 해결:
       - SharedDataAccessor에 TypeReference를 사용하는 메소드를 추가하여, Redis에서 List<LambdaBatchDto>와 같은 제네릭 타입을 역직렬화할 때
         발생하던 타입 변환 오류를 해결했습니다.
       - UnifiedRedisConfig에 PageImpl 객체를 위한 커스텀 Deserializer를 다시 추가하여, 캐시된 Page 객체를 읽어올 때 발생하던 타입 변환 오류를
         해결했습니다.
   - Lettuce 클라이언트 컴파일 오류 수정:
       - UnifiedRedisConfig의 clientResources 메소드 반환 타입을 DefaultClientResources에서 ClientResources 인터페이스로 변경하여 빌드 오류를
         해결했습니다.

  해결된 문제

   - 추천 상품 및 카테고리 상품 조회 시 ClassCastException이 발생하며 기능이 비정상적으로 작동하던 문제
   - lettuce-core 버전과 관련하여 발생하던 빌드 실패 문제

  영향 범위

   - com.tryiton.core.common.service.SharedDataAccessor
   - com.tryiton.core.config.UnifiedRedisConfig
   - com.tryiton.core.recommend.service.RecommendationService
   - 추천 시스템 및 Redis 캐시를 사용하는 모든 기능의 안정성 향상
