### PR TITLE
refactor: ObjectMapper를 사용하여 안전한 타입 변환 적용 (#109)

### DIFF
--- a/src/main/java/com/tryiton/core/recommend/service/RecommendationService.java
+++ b/src/main/java/com/tryiton/core/recommend/service/RecommendationService.java
@@ -61,10 +61,8 @@ public class RecommendationService {
             log.info("트렌딩 상품 조회 데이터 타입: {}", rawData != null ? rawData.getClass().getName() : "null");
             
             List<LambdaBatchDto> lambdaProducts = null;
-            if (rawData instanceof List) {
-                lambdaProducts = (List<LambdaBatchDto>) rawData;
-            } else if (rawData instanceof String) {
-                lambdaProducts = objectMapper.readValue((String) rawData, new TypeReference<List<LambdaBatchDto>>() {});
+            if (rawData != null) {
+                lambdaProducts = objectMapper.convertValue(rawData, new TypeReference<List<LambdaBatchDto>>() {});
             }
             
             if (lambdaProducts != null && !lambdaProducts.isEmpty()) {
@@ -96,10 +94,8 @@ public class RecommendationService {
             Object rawData = redisTemplate.opsForValue().get("recommend:trending");
             
             List<Product> products = null;
-            if (rawData instanceof List) {
-                products = (List<Product>) rawData;
-            } else if (rawData instanceof String) {
-                products = objectMapper.readValue((String) rawData, new TypeReference<List<Product>>() {});
+            if (rawData != null) {
+                products = objectMapper.convertValue(rawData, new TypeReference<List<Product>>() {});
             }
             
             if (products != null && !products.isEmpty()) {
@@ -131,10 +127,8 @@ public class RecommendationService {
             Object rawData = redisTemplate.opsForValue().get(key);
             
             List<LambdaBatchDto> lambdaProducts = null;
-            if (rawData instanceof List) {
-                lambdaProducts = (List<LambdaBatchDto>) rawData;
-            } else if (rawData instanceof String) {
-                lambdaProducts = objectMapper.readValue((String) rawData, new TypeReference<List<LambdaBatchDto>>() {});
+            if (rawData != null) {
+                lambdaProducts = objectMapper.convertValue(rawData, new TypeReference<List<LambdaBatchDto>>() {});
             }
             
             if (lambdaProducts != null) {
@@ -168,10 +162,8 @@ public class RecommendationService {
             Object rawData = redisTemplate.opsForValue().get(key);
             
             List<LambdaBatchDto> lambdaProducts = null;
-            if (rawData instanceof List) {
-                lambdaProducts = (List<LambdaBatchDto>) rawData;
-            } else if (rawData instanceof String) {
-                lambdaProducts = objectMapper.readValue((String) rawData, new TypeReference<List<LambdaBatchDto>>() {});
+            if (rawData != null) {
+                lambdaProducts = objectMapper.convertValue(rawData, new TypeReference<List<LambdaBatchDto>>() {});
             }
             
             if (lambdaProducts != null) {
@@ -205,10 +197,8 @@ public class RecommendationService {
             Object rawData = redisTemplate.opsForValue().get(key);
             
             List<LambdaBatchDto> lambdaProducts = null;
-            if (rawData instanceof List) {
-                lambdaProducts = (List<LambdaBatchDto>) rawData;
-            } else if (rawData instanceof String) {
-                lambdaProducts = objectMapper.readValue((String) rawData, new TypeReference<List<LambdaBatchDto>>() {});
+            if (rawData != null) {
+                lambdaProducts = objectMapper.convertValue(rawData, new TypeReference<List<LambdaBatchDto>>() {});
             }
             
             if (lambdaProducts != null) {


### PR DESCRIPTION

  관련 이슈
   - #109

  작업 내용
   - Redis에서 조회한 데이터를 역직렬화하는 과정에서 발생하던 MismatchedInputException과 ClassCastException 오류를 해결했습니다.
   - (1차 수정) shared:trending 키에 서로 다른 데이터 타입(List<Product>와 List<LambdaBatchDto>)이 저장되어 발생하던 캐시 오염 문제를 해결하기 위해, 호환성 메소드(getTrendingProductsAsEntity)에서 캐시를 저장하는 로직을 제거했습니다.
   - (2차 수정) Redis opsForValue()로 조회한 데이터가 List<LinkedHashMap>으로 변환되는 것을 (List<LambdaBatchDto>)로 직접 형 변환하여 발생하던 ClassCastException을 해결했습니다.
   - RecommendationService 내 모든 Redis 조회 로직에서 objectMapper.convertValue를 사용하여 불안전한 형 변환 코드를 제거하고, 명시적이고 안전한 타입 변환을 하도록 리팩토링했습니다.

  변경 사항
   - src/main/java/com/tryiton/core/recommend/service/RecommendationService.java
