### PR TITLE
fix: DB 커넥션 풀 고갈 문제 해결 (#109)

### DIFF
--- a/src/main/java/com/tryiton/core/CoreApplication.java
+++ b/src/main/java/com/tryiton/core/CoreApplication.java
@@ -2,6 +2,7 @@ package com.tryiton.core;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
@@ -10,6 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableJpaAuditing //BaseTimeEntity
 @EnableAsync
 @EnableScheduling
+@EnableCaching
 @SpringBootApplication
 public class CoreApplication {
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈



---

## 📝 작업 내용


  문제 상황
   - 성능 테스트 중 Too many connections 에러와 함께 DB 커넥션 풀이 완전히 고갈되는 현상이 발생했습니다.
   - 원인 분석 결과, 비회원용 메인 페이지 상품 목록을 조회하는 API(GET /api/products/main)가 내부적으로 매우 무거운 랭킹 쿼리를 실행하고 있었고,
     코드에 @Cacheable이 선언되어 있었음에도 불구하고 메인 애플리케이션에 @EnableCaching이 누락되어 캐시가 전혀 동작하지 않고 있었습니다.
   - 이로 인해 모든 요청이 DB에 직접 전달되어 커넥션 풀을 고갈시키는 심각한 성능 병목 현상이 발생했습니다.

  해결 방안
   1. DB 커넥션 풀 고갈 문제 해결:
       - CoreApplication.java에 @EnableCaching 어노테이션을 추가하여 Spring의 캐시 기능을 활성화했습니다.
       - 이를 통해 ProductService의 getMainPageProductsForGuest() 메소드에 이미 존재하던 @Cacheable 기능이 정상적으로 동작하게 됩니다.
       - 이제 무거운 쿼리의 결과가 Redis에 캐싱되어, 반복적인 DB 부하를 원천적으로 차단하고 커넥션 풀을 보호합니다.

   2. 성능 테스트 스위트 개선:
       - 기존의 단편적인 테스트 스크립트들을 모두 제거하고, 실제 운영 환경의 복잡성을 시뮬레이션하는 master_load_test.js로 통합했습니다.
       - TPS 기반 부하 제어: VUser가 아닌 초당 요청 수를 직접 제어하여 목표 성능(TPS)을 정확하게 테스트합니다.
       - 현실적인 사용자 행동 모델링: 구경만 하는 사용자(80%), 장바구니 사용자(15%), 실제 구매자(5%)의 행동 패턴을 가중치를 두어
         시뮬레이션합니다.
       - 비즈니스 지표 측정: 기술 지표 외에 총 주문 수, 예상 매출 등 비즈니스 성과와 직결되는 지표를 함께 측정하여 테스트의 효용성을 높였습니다.
       - API 명세 최신화: 모든 테스트 스크립트의 API 경로, 요청 데이터 형식 등을 실제 컨트롤러 코드와 100% 일치하도록 수정하여 테스트의 정확성을
         확보했습니다.

  기대 효과
   - DB 커넥션 풀 고갈 문제 해결로 인한 서비스 안정성 대폭 향상
   - 캐싱 적용으로 인한 비회원 메인 페이지 응답 속도 개선
   - 현실적인 시나리오 기반의 정교한 성능 테스트 환경 구축


---

### 📷 스크린샷 (선택)


---

## 💬 리뷰 요구사항 (선택)
