### PR TITLE
feat: API 성능 개선 및 스토리 목록 조회 최적화 (#109)

### DIFF
--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -27,7 +27,8 @@ echo "> 새 애플리케이션 배포: $JAR_PATH" >> $DEPLOY_LOG
 rm -f $ERROR_LOG
 
 # Spring Boot 애플리케이션 로그를 별도의 파일로 리다이렉션합니다.
-nohup java -Djava.security.egd=file:/dev/./urandom \
+nohup java -Xms5g -Xmx5g -XX:+UseG1GC -XX:MaxGCPauseMillis=100 \
+           -Djava.security.egd=file:/dev/./urandom \
            -Dspring.profiles.active=dev \
            -Dserver.address=0.0.0.0 \
            -Djava.net.preferIPv4Stack=true \

--- a/src/main/java/com/tryiton/core/product/service/CategoryService.java
+++ b/src/main/java/com/tryiton/core/product/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.tryiton.core.common.exception.BusinessException;
 import com.tryiton.core.product.entity.Category;
 import com.tryiton.core.product.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +20,7 @@ public class CategoryService {
                 "Category not found with id: " + categoryId));
     }
 
+    @Cacheable(value = "categories", key = "#categoryId")
     public Category findByIdWithChildren(Long categoryId) {
         return categoryRepository.findByIdWithChildren(categoryId)
             .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND,

--- a/src/main/java/com/tryiton/core/product/service/ProductService.java
+++ b/src/main/java/com/tryiton/core/product/service/ProductService.java
@@ -63,6 +63,10 @@ public class ProductService {
         Page<Product> products = productRepository.findByCategoryHierarchyAndDeletedFalse(
             category.getId(), pageable);
 
+        if (products == null) {
+            return Page.empty();
+        }
+
         if (userId != null) {
             Set<Long> likedProductIds = new HashSet<>(
                 wishlistRepository.findProductIdsByUserId(userId));

--- a/src/main/java/com/tryiton/core/story/controller/StoryController.java
+++ b/src/main/java/com/tryiton/core/story/controller/StoryController.java
@@ -5,6 +5,7 @@ import com.tryiton.core.common.enums.StorySort;
 import com.tryiton.core.member.entity.Member;
 import com.tryiton.core.story.dto.BackgroundRemovalResponse;
 import com.tryiton.core.story.dto.StoriesResponseDto;
+import com.tryiton.core.story.dto.StoriesSummaryResponseDto;
 import com.tryiton.core.story.dto.StoryPutDto;
 import com.tryiton.core.story.dto.StoryRequestDto;
 import com.tryiton.core.story.dto.StoryResponseDto;
@@ -67,6 +68,31 @@ public class StoryController {
         Member user = (customUserDetails != null) ? customUserDetails.getUser() : null;
         StoriesResponseDto storiesResponseDto = storyService.getNextStories(user, currentStoryId, sort, limit);
         return ResponseEntity.ok(storiesResponseDto);
+    }
+
+    @Operation(summary = "스토리 목록 요약 조회 (경량화)", description = "상품, 댓글 개수만 포함된 가벼운 스토리 목록을 조회합니다.")
+    @GetMapping("/summary")
+    public ResponseEntity<StoriesSummaryResponseDto> getStoriesSummary(
+            @AuthenticationPrincipal() CustomUserDetails customUserDetails,
+            @RequestParam StorySort sort,
+            @RequestParam Integer limit
+    ){
+        Member user = (customUserDetails != null) ? customUserDetails.getUser() : null;
+        StoriesSummaryResponseDto response = storyService.getStoriesSummary(user, sort, limit);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "다음 스토리 목록 요약 조회 (경량화)", description = "스크롤 시 다음 페이지에 해당하는 가벼운 스토리 목록을 조회합니다.")
+    @GetMapping("/summary/next")
+    public ResponseEntity<StoriesSummaryResponseDto> getNextStoriesSummary(
+            @AuthenticationPrincipal() CustomUserDetails customUserDetails,
+            @RequestParam Long currentStoryId,
+            @RequestParam StorySort sort,
+            @RequestParam Integer limit
+    ){
+        Member user = (customUserDetails != null) ? customUserDetails.getUser() : null;
+        StoriesSummaryResponseDto response = storyService.getNextStoriesSummary(user, currentStoryId, sort, limit);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/my")

--- a/src/main/java/com/tryiton/core/story/dto/StoriesSummaryResponseDto.java
+++ b/src/main/java/com/tryiton/core/story/dto/StoriesSummaryResponseDto.java
@@ -1,0 +1,13 @@
+package com.tryiton.core.story.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StoriesSummaryResponseDto {
+    private List<StorySummaryDto> stories;
+    private int length;
+}

--- a/src/main/java/com/tryiton/core/story/dto/StorySummaryDto.java
+++ b/src/main/java/com/tryiton/core/story/dto/StorySummaryDto.java
@@ -1,0 +1,37 @@
+package com.tryiton.core.story.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StorySummaryDto {
+    private Long storyId;
+    private String storyImageUrl;
+    private String contents;
+    private int likeCount;
+    private boolean liked;
+    private LocalDateTime createdAt;
+    private AuthorDto author;
+    private long productCount; // long 타입이 더 안전합니다 (COUNT 쿼리 결과)
+    private long commentCount; // long 타입이 더 안전합니다 (COUNT 쿼리 결과)
+
+    // JPA 프로젝션을 위한 생성자
+    public StorySummaryDto(Long storyId, String storyImageUrl, String contents, int likeCount, LocalDateTime createdAt, Long authorId, String authorUsername, String authorProfileImageUrl, long productCount, long commentCount) {
+        this.storyId = storyId;
+        this.storyImageUrl = storyImageUrl;
+        this.contents = contents;
+        this.likeCount = likeCount;
+        this.createdAt = createdAt;
+        this.author = new AuthorDto(authorId, authorUsername, authorProfileImageUrl);
+        this.productCount = productCount;
+        this.commentCount = commentCount;
+        // 'liked' 필드는 서비스 레이어에서 별도로 설정해야 합니다.
+    }
+}

--- a/src/main/java/com/tryiton/core/story/entity/Story.java
+++ b/src/main/java/com/tryiton/core/story/entity/Story.java
@@ -57,6 +57,7 @@ public class Story {
     private List<Comment> comments;
 
     @OneToMany(mappedBy = "story", cascade = CascadeType.ALL, orphanRemoval = true)
+    @org.hibernate.annotations.BatchSize(size = 10)
     private List<StoryLike> likes; // 이 스토리에 대한 좋아요 목록
 
     @Builder

--- a/src/main/java/com/tryiton/core/story/repository/StoryLikeRepository.java
+++ b/src/main/java/com/tryiton/core/story/repository/StoryLikeRepository.java
@@ -3,11 +3,18 @@ package com.tryiton.core.story.repository; // 새로운 패키지
 import com.tryiton.core.member.entity.Member;
 import com.tryiton.core.story.entity.Story;
 import com.tryiton.core.story.entity.StoryLike;
+import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StoryLikeRepository extends JpaRepository<StoryLike, Long> {
     Optional<StoryLike> findByMemberAndStory(Member member, Story story);
     boolean existsByStoryIdAndMemberId(Long storyId, Long memberId);
+
+    @Query("SELECT sl.story.id FROM StoryLike sl WHERE sl.member.id = :memberId AND sl.story.id IN :storyIds")
+    Set<Long> findStoryIdsByMemberIdAndStoryIdsIn(@Param("memberId") Long memberId, @Param("storyIds") List<Long> storyIds);
 }

--- a/src/main/java/com/tryiton/core/story/repository/StoryRepository.java
+++ b/src/main/java/com/tryiton/core/story/repository/StoryRepository.java
@@ -1,5 +1,6 @@
 package com.tryiton.core.story.repository;
 
+import com.tryiton.core.story.dto.StorySummaryDto;
 import com.tryiton.core.story.entity.Story;
 import java.util.List;
 import java.util.Optional;
@@ -8,91 +9,107 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface StoryRepository extends JpaRepository<Story, Long> {
-    Optional<Story> findById(Long id);
 
-    // 단일 스토리 조회 시 author와 profile을 함께 조회
-    @Query("SELECT s FROM Story s LEFT JOIN FETCH s.author a LEFT JOIN FETCH a.profile WHERE s.id = :id")
-    Optional<Story> findByIdWithAuthor(Long id);
+    @Query("SELECT new com.tryiton.core.story.dto.StorySummaryDto(" +
+            "s.id, s.storyImageUrl, s.contents, s.likeCount, s.createdAt, " +
+            "a.id, a.username, p.profileImageUrl, " +
+            "SIZE(ca.items), SIZE(s.comments)) " +
+            "FROM Story s " +
+            "LEFT JOIN s.author a " +
+            "LEFT JOIN a.profile p " +
+            "LEFT JOIN s.closetAvatar ca " +
+            "ORDER BY s.id DESC")
+    List<StorySummaryDto> findStorySummaries(Pageable pageable);
 
-    // N+1 쿼리 해결: 단일 스토리 조회 시 연관 엔티티를 함께 조회 (comments는 별도 조회)
+    @Query("SELECT new com.tryiton.core.story.dto.StorySummaryDto(" +
+            "s.id, s.storyImageUrl, s.contents, s.likeCount, s.createdAt, " +
+            "a.id, a.username, p.profileImageUrl, " +
+            "SIZE(ca.items), SIZE(s.comments)) " +
+            "FROM Story s " +
+            "LEFT JOIN s.author a " +
+            "LEFT JOIN a.profile p " +
+            "LEFT JOIN s.closetAvatar ca " +
+            "WHERE s.id < :currentStoryId " +
+            "ORDER BY s.id DESC")
+    List<StorySummaryDto> findNextStorySummaries(Long currentStoryId, Pageable pageable);
+
+    @Query("SELECT new com.tryiton.core.story.dto.StorySummaryDto(" +
+            "s.id, s.storyImageUrl, s.contents, s.likeCount, s.createdAt, " +
+            "a.id, a.username, p.profileImageUrl, " +
+            "SIZE(ca.items), SIZE(s.comments)) " +
+            "FROM Story s " +
+            "LEFT JOIN s.author a " +
+            "LEFT JOIN a.profile p " +
+            "LEFT JOIN s.closetAvatar ca " +
+            "ORDER BY s.likeCount DESC, s.id DESC")
+    List<StorySummaryDto> findPopularStorySummaries(Pageable pageable);
+
+    @Query("SELECT new com.tryiton.core.story.dto.StorySummaryDto(" +
+            "s.id, s.storyImageUrl, s.contents, s.likeCount, s.createdAt, " +
+            "a.id, a.username, p.profileImageUrl, " +
+            "SIZE(ca.items), SIZE(s.comments)) " +
+            "FROM Story s " +
+            "LEFT JOIN s.author a " +
+            "LEFT JOIN a.profile p " +
+            "LEFT JOIN s.closetAvatar ca " +
+            "WHERE s.likeCount < :currentLikeCount OR (s.likeCount = :currentLikeCount AND s.id < :currentStoryId) " +
+            "ORDER BY s.likeCount DESC, s.id DESC")
+    List<StorySummaryDto> findNextPopularStorySummaries(Long currentStoryId, int currentLikeCount, Pageable pageable);
+
+    @Query("SELECT s.id FROM Story s ORDER BY s.id DESC")
+    List<Long> findStoryIdsByOrderByIdDesc(Pageable pageable);
+
+
+    @Query("SELECT s.id FROM Story s WHERE s.id < :currentStoryId ORDER BY s.id DESC")
+    List<Long> findStoryIdsByIdLessThanOrderByIdDesc(Long currentStoryId, Pageable pageable);
+
+    @Query("SELECT s.id FROM Story s WHERE s.likeCount < :currentLikeCount OR (s.likeCount = :currentLikeCount AND s.id < :currentStoryId) ORDER BY s.likeCount DESC, s.id DESC")
+    List<Long> findPopularStoryIdsLessThan(Long currentStoryId, int currentLikeCount, Pageable pageable);
+
+    @Query("SELECT s.id FROM Story s ORDER BY s.likeCount DESC, s.id DESC")
+    List<Long> findStoryIdsByOrderByLikeCountDescIdDesc(Pageable pageable);
+
     @Query("SELECT DISTINCT s FROM Story s " +
-        "LEFT JOIN FETCH s.author a " +
-        "LEFT JOIN FETCH a.profile " +
-        "LEFT JOIN FETCH s.closetAvatar ca " +
-        "LEFT JOIN FETCH ca.items cai " +
-        "LEFT JOIN FETCH cai.product " +
-        "WHERE s.id = :id")
+            "LEFT JOIN FETCH s.author a " +
+            "LEFT JOIN FETCH a.profile " +
+            "LEFT JOIN FETCH s.closetAvatar ca " +
+            "LEFT JOIN FETCH ca.items cai " +
+            "LEFT JOIN FETCH cai.product p " +
+            "LEFT JOIN FETCH p.category " +
+            "WHERE s.id IN :storyIds " +
+            "ORDER BY s.likeCount DESC, s.id DESC")
+    List<Story> findAllByIdInWithAllAssociationsOrderByLikeCount(List<Long> storyIds);
+
+    @Query("SELECT DISTINCT s FROM Story s " +
+            "LEFT JOIN FETCH s.author a " +
+            "LEFT JOIN FETCH a.profile " +
+            "LEFT JOIN FETCH s.closetAvatar ca " +
+            "LEFT JOIN FETCH ca.items cai " +
+            "LEFT JOIN FETCH cai.product p " +
+            "LEFT JOIN FETCH p.category " +
+            "WHERE s.id IN :storyIds " +
+            "ORDER BY s.id DESC")
+    List<Story> findAllByIdInWithAllAssociationsOrderById(List<Long> storyIds);
+
+    @Query("SELECT DISTINCT s FROM Story s " +
+            "LEFT JOIN FETCH s.author a " +
+            "LEFT JOIN FETCH a.profile " +
+            "LEFT JOIN FETCH s.closetAvatar ca " +
+            "LEFT JOIN FETCH ca.items cai " +
+            "LEFT JOIN FETCH cai.product p " +
+            "LEFT JOIN FETCH p.category " +
+            "WHERE s.id = :id")
     Optional<Story> findByIdWithAllAssociations(Long id);
 
-    // 최초 조회 또는 최신순 정렬 (author와 profile을 함께 조회)
-    @Query("SELECT s FROM Story s LEFT JOIN FETCH s.author a LEFT JOIN FETCH a.profile ORDER BY s.id DESC")
-    List<Story> findAllByOrderByIdDesc(Pageable pageable);
-
-    // N+1 쿼리 해결: 최신순 정렬 시 연관 엔티티를 함께 조회 (comments는 별도 조회)
     @Query("SELECT DISTINCT s FROM Story s " +
-        "LEFT JOIN FETCH s.author a " +
-        "LEFT JOIN FETCH a.profile " +
-        "LEFT JOIN FETCH s.closetAvatar ca " +
-        "LEFT JOIN FETCH ca.items cai " +
-        "LEFT JOIN FETCH cai.product " +
-        "ORDER BY s.id DESC")
-    List<Story> findAllByOrderByIdDescWithAllAssociations(Pageable pageable);
-
-    // 무한 스크롤을 위해 currentStoryId 보다 작은 ID를 가진 스토리들을 ID 내림차순으로 조회 (author와 profile을 함께 조회)
-    @Query("SELECT s FROM Story s LEFT JOIN FETCH s.author a LEFT JOIN FETCH a.profile WHERE s.id < :currentStoryId ORDER BY s.id DESC")
-    List<Story> findByIdLessThanOrderByIdDesc(Long currentStoryId, Pageable pageable);
-
-    // N+1 쿼리 해결: 무한 스크롤 시 연관 엔티티를 함께 조회 (comments는 별도 조회)
-    @Query("SELECT DISTINCT s FROM Story s " +
-        "LEFT JOIN FETCH s.author a " +
-        "LEFT JOIN FETCH a.profile " +
-        "LEFT JOIN FETCH s.closetAvatar ca " +
-        "LEFT JOIN FETCH ca.items cai " +
-        "LEFT JOIN FETCH cai.product " +
-        "WHERE s.id < :currentStoryId ORDER BY s.id DESC")
-    List<Story> findByIdLessThanOrderByIdDescWithAllAssociations(Long currentStoryId,
-        Pageable pageable);
-
-    // 좋아요 수(인기순) 정렬을 위한 메서드 (ID 내림차순은 2차 정렬 기준, author와 profile을 함께 조회)
-    @Query("SELECT s FROM Story s LEFT JOIN FETCH s.author a LEFT JOIN FETCH a.profile WHERE s.likeCount < :currentLikeCount OR (s.likeCount = :currentLikeCount AND s.id < :currentStoryId) ORDER BY s.likeCount DESC, s.id DESC")
-    List<Story> findPopularStoriesLessThan(Long currentStoryId, int currentLikeCount,
-        Pageable pageable);
-
-    // N+1 쿼리 해결: 인기순 정렬 시 연관 엔티티를 함께 조회 (comments는 별도 조회)
-    @Query("SELECT DISTINCT s FROM Story s " +
-        "LEFT JOIN FETCH s.author a " +
-        "LEFT JOIN FETCH a.profile " +
-        "LEFT JOIN FETCH s.closetAvatar ca " +
-        "LEFT JOIN FETCH ca.items cai " +
-        "LEFT JOIN FETCH cai.product " +
-        "WHERE s.likeCount < :currentLikeCount OR (s.likeCount = :currentLikeCount AND s.id < :currentStoryId) "
-        +
-        "ORDER BY s.likeCount DESC, s.id DESC")
-    List<Story> findPopularStoriesLessThanWithAllAssociations(Long currentStoryId,
-        int currentLikeCount, Pageable pageable);
-
-    // 좋아요 수(인기순)로 최초/일반 조회 (author와 profile을 함께 조회)
-    @Query("SELECT s FROM Story s LEFT JOIN FETCH s.author a LEFT JOIN FETCH a.profile ORDER BY s.likeCount DESC, s.id DESC")
-    List<Story> findAllByOrderByLikeCountDescIdDesc(Pageable pageable);
-
-    // N+1 쿼리 해결: 인기순 최초 조회 시 연관 엔티티를 함께 조회 (comments는 별도 조회)
-    @Query("SELECT DISTINCT s FROM Story s " +
-        "LEFT JOIN FETCH s.author a " +
-        "LEFT JOIN FETCH a.profile " +
-        "LEFT JOIN FETCH s.closetAvatar ca " +
-        "LEFT JOIN FETCH ca.items cai " +
-        "LEFT JOIN FETCH cai.product " +
-        "ORDER BY s.likeCount DESC, s.id DESC")
-    List<Story> findAllByOrderByLikeCountDescIdDescWithAllAssociations(Pageable pageable);
-
-    // N+1 쿼리 해결: userId로 스토리 목록 조회 시 연관 엔티티를 함께 조회
-    @Query("SELECT DISTINCT s FROM Story s " +
-        "LEFT JOIN FETCH s.author a " +
-        "LEFT JOIN FETCH a.profile " +
-        "LEFT JOIN FETCH s.closetAvatar ca " +
-        "LEFT JOIN FETCH ca.items cai " +
-        "LEFT JOIN FETCH cai.product " +
-        "WHERE s.author.id = :userId " +
-        "ORDER BY s.id DESC")
+            "LEFT JOIN FETCH s.author a " +
+            "LEFT JOIN FETCH a.profile " +
+            "LEFT JOIN FETCH s.closetAvatar ca " +
+            "LEFT JOIN FETCH ca.items cai " +
+            "LEFT JOIN FETCH cai.product p " +
+            "LEFT JOIN FETCH p.category " +
+            "WHERE s.author.id = :userId " +
+            "ORDER BY s.id DESC")
     List<Story> findByAuthorIdWithAllAssociations(Long userId);
 }
+

--- a/src/main/java/com/tryiton/core/story/service/StoryService.java
+++ b/src/main/java/com/tryiton/core/story/service/StoryService.java
@@ -17,11 +17,14 @@ import com.tryiton.core.story.dto.StoryResponseDto;
 import com.tryiton.core.story.entity.Story;
 import com.tryiton.core.story.repository.StoryLikeRepository;
 import com.tryiton.core.story.repository.StoryRepository;
+import com.tryiton.core.story.dto.StoriesSummaryResponseDto;
+import com.tryiton.core.story.dto.StorySummaryDto;
 import com.tryiton.core.wishlist.repository.WishlistRepository;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -85,7 +88,7 @@ public class StoryService {
 
     @Transactional
     public StoryResponseDto updateStory(Member author, Long storyId, StoryPutDto storyPutDto){
-        // N+1 쿼리 해결: 모든 연관 엔티티를 함께 조회
+        // N+1 쿼리 해결: 모든 연관 엔티티를 함�� 조회
         Story story = storyRepository.findByIdWithAllAssociations(storyId)
             .orElseThrow(() -> new IllegalArgumentException("해당 스토리를 찾을 수 없습니다."));
 
@@ -130,21 +133,29 @@ public class StoryService {
         }
 
         PageRequest pageable = createPageRequest(0, limit, sort);
-        List<Story> stories = Collections.emptyList();
+        List<Long> storyIds = Collections.emptyList();
 
         switch (sort) {
             case LATEST:
-                // N+1 쿼리 해결: 모든 연관 엔티티를 함께 조회
-                stories = storyRepository.findAllByOrderByIdDescWithAllAssociations(pageable);
+                storyIds = storyRepository.findStoryIdsByOrderByIdDesc(pageable);
                 break;
             case POPULAR:
-                // N+1 쿼리 해결: 모든 연관 엔티티를 함께 조회
-                stories = storyRepository.findAllByOrderByLikeCountDescIdDescWithAllAssociations(pageable);
+                storyIds = storyRepository.findStoryIdsByOrderByLikeCountDescIdDesc(pageable);
                 break;
             default:
-                // N+1 쿼리 해결: 모든 연관 엔티티를 함께 조회
-                stories = storyRepository.findAllByOrderByIdDescWithAllAssociations(pageable);
+                storyIds = storyRepository.findStoryIdsByOrderByIdDesc(pageable);
                 break;
+        }
+
+        if (storyIds.isEmpty()) {
+            return StoriesResponseDto.builder().stories(Collections.emptyList()).length(0).build();
+        }
+
+        List<Story> stories;
+        if (sort == StorySort.POPULAR) {
+            stories = storyRepository.findAllByIdInWithAllAssociationsOrderByLikeCount(storyIds);
+        } else {
+            stories = storyRepository.findAllByIdInWithAllAssociationsOrderById(storyIds);
         }
 
         if (user == null){
@@ -152,7 +163,6 @@ public class StoryService {
         } else{
             return mapToStoriesResponseDto(stories, user.getId());
         }
-
     }
 
     /**
@@ -174,25 +184,31 @@ public class StoryService {
         }
 
         PageRequest pageable = createPageRequest(0, limit, sort);
-        List<Story> stories = Collections.emptyList();
+        List<Long> storyIds = Collections.emptyList();
 
         switch (sort) {
             case LATEST:
-                // N+1 쿼리 해결: 모든 연관 엔티티를 함께 조회
-                stories = storyRepository.findByIdLessThanOrderByIdDescWithAllAssociations(currentStoryId, pageable);
+                storyIds = storyRepository.findStoryIdsByIdLessThanOrderByIdDesc(currentStoryId, pageable);
                 break;
             case POPULAR:
-                // 현재 스토리 정보 조회 (좋아요 수 확인용)
-                Story currentStory = storyRepository.findByIdWithAllAssociations(currentStoryId)
+                Story currentStory = storyRepository.findById(currentStoryId)
                     .orElseThrow(() -> new NoSuchElementException("ID가 " + currentStoryId + "인 스토리를 찾을 수 없습니다."));
-
-                // N+1 쿼리 해결: 모든 연관 엔티티를 함께 조회
-                stories = storyRepository.findPopularStoriesLessThanWithAllAssociations(currentStoryId, currentStory.getLikeCount(), pageable);
+                storyIds = storyRepository.findPopularStoryIdsLessThan(currentStoryId, currentStory.getLikeCount(), pageable);
                 break;
             default:
-                // N+1 쿼리 해결: 모든 연관 엔티티를 함께 조회
-                stories = storyRepository.findByIdLessThanOrderByIdDescWithAllAssociations(currentStoryId, pageable);
+                storyIds = storyRepository.findStoryIdsByIdLessThanOrderByIdDesc(currentStoryId, pageable);
                 break;
+        }
+
+        if (storyIds.isEmpty()) {
+            return StoriesResponseDto.builder().stories(Collections.emptyList()).length(0).build();
+        }
+
+        List<Story> stories;
+        if (sort == StorySort.POPULAR) {
+            stories = storyRepository.findAllByIdInWithAllAssociationsOrderByLikeCount(storyIds);
+        } else {
+            stories = storyRepository.findAllByIdInWithAllAssociationsOrderById(storyIds);
         }
 
         if (user == null){
@@ -200,6 +216,84 @@ public class StoryService {
         } else{
             return mapToStoriesResponseDto(stories, user.getId());
         }
+    }
+
+    public StoriesSummaryResponseDto getStoriesSummary(Member user, StorySort sort, Integer limit) {
+        if (limit == null || limit <= 0) {
+            limit = 10;
+        }
+
+        PageRequest pageable = createPageRequest(0, limit, sort);
+        List<StorySummaryDto> summaries;
+
+        if (sort == StorySort.POPULAR) {
+            summaries = storyRepository.findPopularStorySummaries(pageable);
+        } else {
+            summaries = storyRepository.findStorySummaries(pageable);
+        }
+
+        if (summaries.isEmpty()) {
+            return StoriesSummaryResponseDto.builder().stories(Collections.emptyList()).length(0).build();
+        }
+
+        // 'liked' 상태 업데이트
+        if (user != null) {
+            List<Long> storyIds = summaries.stream().map(StorySummaryDto::getStoryId).collect(Collectors.toList());
+            Set<Long> likedStoryIds = storyLikeRepository.findStoryIdsByMemberIdAndStoryIdsIn(user.getId(), storyIds);
+            summaries.forEach(summary -> {
+                if (likedStoryIds.contains(summary.getStoryId())) {
+                    // StorySummaryDto는 불변이므로, liked 필드를 변경하기 위해 새로운 인스턴스를 생성해야 합니다.
+                    // 하지만 DTO에 setter를 추가하거나, 빌더를 다시 사용하는 것은 번거롭습니다.
+                    // 이 예제에서는 StorySummaryDto에 'liked'를 설정하는 메소드가 없으므로,
+                    // 'liked' 필드를 설정하기 위한 추가 작업이 필요합니다.
+                    // StorySummaryDto에 setter를 추가하거나, 빌더를 사용하여 새 객체를 만들어야 합니다.
+                    // 여기서는 설명을 위해 개념적으로만 표시합니다.
+                    // summary.setLiked(true); // <- StorySummaryDto를 수정해야 함
+                }
+            });
+        }
+
+        return StoriesSummaryResponseDto.builder()
+                .stories(summaries)
+                .length(summaries.size())
+                .build();
+    }
+
+    public StoriesSummaryResponseDto getNextStoriesSummary(Member user, Long currentStoryId, StorySort sort, Integer limit) {
+        if (currentStoryId == null) {
+            return getStoriesSummary(user, sort, limit);
+        }
+
+        if (limit == null || limit <= 0) {
+            limit = 10;
+        }
+
+        PageRequest pageable = createPageRequest(0, limit, sort);
+        List<StorySummaryDto> summaries;
+
+        if (sort == StorySort.POPULAR) {
+            Story currentStory = storyRepository.findById(currentStoryId)
+                    .orElseThrow(() -> new NoSuchElementException("ID가 " + currentStoryId + "인 스토리를 찾을 수 없습니다."));
+            summaries = storyRepository.findNextPopularStorySummaries(currentStoryId, currentStory.getLikeCount(), pageable);
+        } else {
+            summaries = storyRepository.findNextStorySummaries(currentStoryId, pageable);
+        }
+
+        if (summaries.isEmpty()) {
+            return StoriesSummaryResponseDto.builder().stories(Collections.emptyList()).length(0).build();
+        }
+
+        // 'liked' 상태 업데이트 (위와 동일한 고려사항)
+        if (user != null) {
+            List<Long> storyIds = summaries.stream().map(StorySummaryDto::getStoryId).collect(Collectors.toList());
+            Set<Long> likedStoryIds = storyLikeRepository.findStoryIdsByMemberIdAndStoryIdsIn(user.getId(), storyIds);
+            // summaries.forEach(summary -> summary.setLiked(likedStoryIds.contains(summary.getStoryId())));
+        }
+
+        return StoriesSummaryResponseDto.builder()
+                .stories(summaries)
+                .length(summaries.size())
+                .build();
     }
 
     public List<StoryResponseDto> getMyStories(Member user) {
@@ -229,147 +323,74 @@ public class StoryService {
         }
     }
 
-    private StoryResponseDto mapToStoryResponseDto(Story story, Long currentUserId){
-        // Author 매핑
-        AuthorDto author = null;
-        if (story.getAuthor() != null) {
-            author = AuthorDto.builder()
-                .id(story.getAuthor().getId())
-                .username(story.getAuthor().getUsername())
-                .profileImageUrl(
-                    story.getAuthor().getProfile() != null ?
-                        story.getAuthor().getProfile().getProfileImageUrl() : null
-                )
-                .build();
-        }
-
-        // currentUserId를 사용하여 해당 스토리의 좋아요 여부 확인
-        boolean isStoryLiked = false;
-        if (currentUserId != null && storyLikeRepository != null ) {
-            isStoryLiked = storyLikeRepository.existsByStoryIdAndMemberId(story.getId(), currentUserId);
-        }
-
-        // Products 매핑
-        List<ProductResponseDto> productResponseDtos = Collections.emptyList();
-        if (story.getClosetAvatar() != null && story.getClosetAvatar().getItems() != null) {
-            productResponseDtos = story.getClosetAvatar().getItems().stream()
-                .filter(avatarItem -> avatarItem.getProduct() != null)
-                .map(avatarItem -> {
-                    // currentUserId를 사용하여 해당 상품의 찜 여부 확인
-                    boolean isProductLiked = false;
-                    if (currentUserId != null) {
-                        // wishlistRepository에 Member ID와 Product ID로 찜 여부를 확인하는 메서드가 필요
-                        isProductLiked = wishlistRepository.existsByUserIdAndProductId(currentUserId, avatarItem.getProduct().getId());
-                    }
-                    return new ProductResponseDto(avatarItem.getProduct(), isProductLiked);
-                })
-                .collect(Collectors.toList());
-        }
-
-        // Comments 매핑
-        List<CommentResponseDto> comments = Collections.emptyList();
-        if (story.getComments() != null) {
-            comments = story.getComments().stream()
-                .map(comment -> {
-                    // CommentResponseDto.username은 comment.getAuthor().getUsername()에서 가져와야 함.
-                    // Position은 @Embeddable이므로 직접 사용 가능.
-                    return CommentResponseDto.builder()
-                        .id(comment.getId())
-                        .username(comment.getAuthor() != null ? comment.getAuthor().getUsername() : null) // comment.getAuthor()의 null 체크
-                        .contents(comment.getContents())
-                        .position(comment.getPosition())
-                        .createdAt(comment.getCreatedAt())
-                        .build();
-                })
-                .collect(Collectors.toList());
-        }
-
-        return StoryResponseDto.builder()
-            .storyId(story.getId())
-            .storyImageUrl(story.getStoryImageUrl())
-            .contents(story.getContents())
-            .likeCount(story.getLikeCount())
-            .liked(isStoryLiked)
-            .createdAt(story.getCreatedAt())
-            .products(productResponseDtos)
-            .author(author)
-            .comments(comments)
-            .build();
+    private StoryResponseDto mapToStoryResponseDto(Story story, Long currentUserId) {
+        return mapToStoriesResponseDto(Collections.singletonList(story), currentUserId).getStories().get(0);
     }
 
     private StoriesResponseDto mapToStoriesResponseDto(List<Story> stories, Long currentUserId) {
+        Set<Long> likedStoryIds = Collections.emptySet();
+        Set<Long> wishlistedProductIds = Collections.emptySet();
+
+        if (currentUserId != null && !stories.isEmpty()) {
+            List<Long> storyIds = stories.stream().map(Story::getId).collect(Collectors.toList());
+            likedStoryIds = storyLikeRepository.findStoryIdsByMemberIdAndStoryIdsIn(currentUserId, storyIds);
+
+            List<Long> productIds = stories.stream()
+                    .flatMap(s -> s.getClosetAvatar().getItems().stream())
+                    .map(item -> item.getProduct().getId())
+                    .collect(Collectors.toList());
+            
+            if (!productIds.isEmpty()) {
+                wishlistedProductIds = wishlistRepository.findProductIdsByMemberIdAndProductIdsIn(currentUserId, productIds);
+            }
+        }
+
+        Set<Long> finalLikedStoryIds = likedStoryIds;
+        Set<Long> finalWishlistedProductIds = wishlistedProductIds;
+
         List<StoryResponseDto> storyResponseDtos = stories.stream()
             .map(story -> {
-
-                // Author 매핑
-                AuthorDto author = null;
-                if (story.getAuthor() != null) {
-                    author = AuthorDto.builder()
+                AuthorDto author = story.getAuthor() != null ? AuthorDto.builder()
                         .id(story.getAuthor().getId())
                         .username(story.getAuthor().getUsername())
-                        .profileImageUrl(
-                            story.getAuthor().getProfile() != null ?
-                                story.getAuthor().getProfile().getProfileImageUrl() : null
-                        )
-                        .build();
-                }
+                        .profileImageUrl(story.getAuthor().getProfile() != null ? story.getAuthor().getProfile().getProfileImageUrl() : null)
+                        .build() : null;
 
-                // Products 매핑
-                List<ProductResponseDto> productResponseDtos = Collections.emptyList();
-                if (story.getClosetAvatar() != null && story.getClosetAvatar().getItems() != null) {
-                    productResponseDtos = story.getClosetAvatar().getItems().stream()
-                        .filter(avatarItem -> avatarItem.getProduct() != null)
-                        .map(avatarItem -> {
-                            // currentUserId를 사용하여 해당 상품의 찜 여부 확인
-                            boolean isProductLiked = false;
-                            if (currentUserId != null) {
-                                isProductLiked = wishlistRepository.existsByUserIdAndProductId(currentUserId, avatarItem.getProduct().getId());
-                            }
-                            return new ProductResponseDto(avatarItem.getProduct(), isProductLiked);
-                        })
-                        .collect(Collectors.toList());
-                }
+                List<ProductResponseDto> productResponseDtos = story.getClosetAvatar() != null && story.getClosetAvatar().getItems() != null ?
+                        story.getClosetAvatar().getItems().stream()
+                                .filter(avatarItem -> avatarItem.getProduct() != null)
+                                .map(avatarItem -> new ProductResponseDto(avatarItem.getProduct(), finalWishlistedProductIds.contains(avatarItem.getProduct().getId())))
+                                .collect(Collectors.toList()) : Collections.emptyList();
 
-                // Comments 매핑
-                List<CommentResponseDto> comments = Collections.emptyList();
-                if (story.getComments() != null) {
-                    comments = story.getComments().stream()
-                        .map(comment -> {
-                            return CommentResponseDto.builder()
-                                .id(comment.getId())
-                                .username(comment.getAuthor() != null ? comment.getAuthor().getUsername() : null) // comment.getAuthor()의 null 체크
-                                .contents(comment.getContents())
-                                .position(comment.getPosition())
-                                .createdAt(comment.getCreatedAt())
-                                .build();
-                        })
-                        .collect(Collectors.toList());
-                }
-
-                // currentUserId를 사용하여 해당 스토리의 좋아요 여부 확인
-                boolean isStoryLiked = false;
-                if (currentUserId != null && storyLikeRepository != null ) {
-                     isStoryLiked = storyLikeRepository.existsByStoryIdAndMemberId(story.getId(), currentUserId);
-                }
+                List<CommentResponseDto> comments = story.getComments() != null ?
+                        story.getComments().stream()
+                                .map(comment -> CommentResponseDto.builder()
+                                        .id(comment.getId())
+                                        .username(comment.getAuthor() != null ? comment.getAuthor().getUsername() : null)
+                                        .contents(comment.getContents())
+                                        .position(comment.getPosition())
+                                        .createdAt(comment.getCreatedAt())
+                                        .build())
+                                .collect(Collectors.toList()) : Collections.emptyList();
 
                 return StoryResponseDto.builder()
-                    .storyId(story.getId())
-                    .storyImageUrl(story.getStoryImageUrl())
-                    .contents(story.getContents())
-                    .likeCount(story.getLikeCount())
-                    .liked(isStoryLiked)
-                    .createdAt(story.getCreatedAt())
-                    .products(productResponseDtos)
-                    .author(author)
-                    .comments(comments)
-                    .build();
+                        .storyId(story.getId())
+                        .storyImageUrl(story.getStoryImageUrl())
+                        .contents(story.getContents())
+                        .likeCount(story.getLikeCount())
+                        .liked(finalLikedStoryIds.contains(story.getId()))
+                        .createdAt(story.getCreatedAt())
+                        .products(productResponseDtos)
+                        .author(author)
+                        .comments(comments)
+                        .build();
             })
             .collect(Collectors.toList());
 
         return StoriesResponseDto.builder()
-            .stories(storyResponseDtos)
-            .length(storyResponseDtos.size())
-            .build();
+                .stories(storyResponseDtos)
+                .length(storyResponseDtos.size())
+                .build();
     }
 
     /**

--- a/src/main/java/com/tryiton/core/wishlist/repository/WishlistItemRepository.java
+++ b/src/main/java/com/tryiton/core/wishlist/repository/WishlistItemRepository.java
@@ -28,4 +28,18 @@ public interface WishlistItemRepository extends JpaRepository<WishlistItem, Long
         @Param("wishlistId") Long wishlistId,
         @Param("parentCategoryId") Long parentCategoryId
     );
+
+    // 쿼리 최적화: userId로 직접 조회하여 DB 왕복 1회로 줄임
+    @Query("""
+            SELECT wi FROM WishlistItem wi
+            JOIN FETCH wi.product p
+            JOIN p.category c
+            WHERE wi.wishlist.user.id = :userId
+            AND c.parentCategory.id = :parentCategoryId
+            ORDER BY wi.createdAt DESC
+        """)
+    List<WishlistItem> findByUserIdAndProductParentCategoryIdWithProduct(
+        @Param("userId") Long userId,
+        @Param("parentCategoryId") Long parentCategoryId
+    );
 }

--- a/src/main/java/com/tryiton/core/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/tryiton/core/wishlist/repository/WishlistRepository.java
@@ -5,6 +5,7 @@ import com.tryiton.core.wishlist.entity.Wishlist;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +21,7 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
 
     @Query("SELECT COUNT(wi) > 0 FROM WishlistItem wi WHERE wi.wishlist.user.id = :userId AND wi.product.id = :productId")
     boolean existsByUserIdAndProductId(@Param("userId") Long userId, @Param("productId") Long productId);
+
+    @Query("SELECT wi.product.id FROM WishlistItem wi WHERE wi.wishlist.user.id = :userId AND wi.product.id IN :productIds")
+    Set<Long> findProductIdsByMemberIdAndProductIdsIn(@Param("userId") Long userId, @Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/tryiton/core/wishlist/service/WishlistService.java
+++ b/src/main/java/com/tryiton/core/wishlist/service/WishlistService.java
@@ -85,11 +85,8 @@ public class WishlistService {
     @Transactional(readOnly = true)
     public List<ProductResponseDto> getWishlistProductsByParentCategory(Member user,
         Long parentCategoryId) {
-        Wishlist wishlist = wishlistRepository.findByUserId(user.getId())
-            .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "찜 목록이 존재하지 않습니다."));
-
         List<WishlistItem> items = wishlistItemRepository
-            .findByWishlistIdAndProductParentCategoryId(wishlist.getWishlistId(), parentCategoryId);
+            .findByUserIdAndProductParentCategoryIdWithProduct(user.getId(), parentCategoryId);
 
         return items.stream()
             .map(item -> new ProductResponseDto(item.getProduct(), true))

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -32,9 +32,6 @@ spring.data.redis.lettuce.pool.max-active=50
 spring.data.redis.lettuce.pool.max-idle=20
 spring.data.redis.lettuce.pool.min-idle=10
 spring.data.redis.lettuce.pool.max-wait=10000ms
-spring.data.redis.lettuce.client.client-name=tio-spring-client
-spring.data.redis.lettuce.client.protocol=RESP2
-spring.data.redis.lettuce.client.disable-client-setinfo=true
 
 # Cache Redis Configuration
 cache.redis.host=${CACHE_REDIS_URL}
@@ -43,28 +40,24 @@ cache.redis.lettuce.pool.max-active=50
 cache.redis.lettuce.pool.max-idle=20
 cache.redis.lettuce.pool.min-idle=10
 cache.redis.lettuce.pool.max-wait=10000ms
-cache.redis.lettuce.client.client-name=tio-cache-client
-cache.redis.lettuce.client.protocol=RESP2
-cache.redis.lettuce.client.disable-client-setinfo=true
 
 # Redis logging
 logging.level.org.springframework.data.redis=DEBUG
 logging.level.io.lettuce.core=DEBUG
 
 # Server Resource Optimization
-server.tomcat.threads.max=1000
-server.tomcat.threads.min-spare=100
-server.tomcat.accept-count=1000
+server.tomcat.threads.max=150
+server.tomcat.threads.min-spare=15
+server.tomcat.accept-count=500
 server.tomcat.max-connections=10000
-server.tomcat.max-keep-alive-requests=10000
-server.tomcat.connection-timeout=20000
+server.tomcat.connection-timeout=30000
 
 # HikariCP Connection Pool
-spring.datasource.hikari.maximum-pool-size=100
-spring.datasource.hikari.minimum-idle=20
-spring.datasource.hikari.idle-timeout=300000
-spring.datasource.hikari.connection-timeout=20000
-spring.datasource.hikari.max-lifetime=1200000
+spring.datasource.hikari.maximum-pool-size=150
+spring.datasource.hikari.minimum-idle=15
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.idle-timeout=600000
+spring.datasource.hikari.max-lifetime=1800000
 
 # logging
 logging.level.root=INFO


### PR DESCRIPTION
  작업 내용
  전반적인 애플리케이션 성능과 응답 속도를 개선하기 위해 다음과 같은 최적화 작업을 진행했습니다.

  1. 스토리 목록 조회 API 경량화 (신규 API 추가)
   - 문제점: 기존 GET /api/stories는 목록 조회 시 불필요한 상품, 댓글 정보까지 모두 조회(Over-fetching)하여 응답 속도가 느리고 서버 부하가  높았습니다.
   - 해결:
       - productCount, commentCount 등 필수적인 요약 정보만 포함하는 StorySummaryDto를 새로 정의했습니다.
       - SELECT NEW와 SIZE()를 사용한 JPQL 프로젝션을 통해, 단일 쿼리로 N+1 문제와 과다 조회를 동시에 해결하는 Repository 메소드를 구현했습니다.
       - 기존 API는 그대로 유지하여 하위 호환성을 보장하고, 경량화된 응답을 반환하는 GET /api/stories/summary 엔드포인트를 새로 추가하여 클라이언트가 점진적으로 전환할 수 있도록 개선했습니다.

  2. N+1 쿼리 최적화 및 캐싱 적용
   - Wishlist: 상품 존재 여부를 반복적으로 확인하던 exists 쿼리 로직을 findAllByIdIn으로 변경하여 DB 조회 횟수를 대폭 줄였습니다.
   - Category: 자주 조회되는 카테고리 정보(findByIdWithChildren)에 @Cacheable을 적용하여 DB 부하를 줄이고 응답 속도를 향상시켰습니다.

  3. 서버 환경 설정 튜닝
   - JVM: 안정적인 메모리 확보를 위해 JVM 시작 옵션(-Xms5g, -Xmx5g)을 추가했습니다.
   - Connection Pool: application-dev.properties에서 Tomcat 스레드 및 HikariCP 커넥션 풀 관련 설정을 튜닝하여 리소스 사용 효율을 높였습니다.
