### PR TITLE
fix: N+1 병목 해소 OR절 IN으로 개선

### DIFF
--- a/src/main/java/com/tryiton/core/product/repository/ProductRepository.java
+++ b/src/main/java/com/tryiton/core/product/repository/ProductRepository.java
@@ -57,11 +57,19 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
         "ORDER BY p.createAt DESC")
     Page<Product> findByCategoryHierarchyAndDeletedFalse(@Param("categoryId") Long categoryId, Pageable pageable);
 
-    // JPQL 프로젝션을 사용하여 ProductSummaryDto를 직접 조회
+    // JPQL 프로젝션을 사용하여 ProductSummaryDto를 직접 조회 (최적화)
     @Query("SELECT new com.tryiton.core.product.dto.ProductSummaryDto(p.id, p.productName, p.img1, p.price, p.sale, p.brand, p.wishlistCount, p.createAt, p.category.id, p.category.categoryName) " +
-            "FROM Product p WHERE p.deleted = false AND " +
-            "(p.category.id = :categoryId OR p.category.parentCategory.id = :categoryId)")
-    Page<ProductSummaryDto> findSummaryByCategoryHierarchy(@Param("categoryId") Long categoryId, Pageable pageable);
+            "FROM Product p JOIN p.category c WHERE p.deleted = false AND c.id IN :categoryIds")
+    Page<ProductSummaryDto> findSummaryByCategoryIds(@Param("categoryIds") List<Long> categoryIds, Pageable pageable);
+
+    // 상품 상세 정보와 '좋아요' 여부를 한 번의 쿼리로 조회 (N+1 문제 해결)
+    @Query("SELECT p, CASE WHEN w.id IS NOT NULL THEN true ELSE false END " +
+            "FROM Product p " +
+            "LEFT JOIN p.category " +
+            "LEFT JOIN FETCH p.variants " +
+            "LEFT JOIN Wishlist w ON w.product = p AND w.member.id = :userId " +
+            "WHERE p.id = :productId AND p.deleted = false")
+    Optional<Object[]> findProductWithLikeStatus(@Param("userId") Long userId, @Param("productId") Long productId);
     
     // 시드 기반 랜덤 정렬로 페이지네이션 지원
     @Query(value = "SELECT * FROM product WHERE deleted = false AND category_id IN " +

--- a/src/main/java/com/tryiton/core/product/service/CategoryService.java
+++ b/src/main/java/com/tryiton/core/product/service/CategoryService.java
@@ -8,6 +8,10 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
@@ -25,5 +29,22 @@ public class CategoryService {
         return categoryRepository.findByIdWithChildren(categoryId)
             .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND,
                 "Category not found with id: " + categoryId));
+    }
+
+    @Cacheable(value = "categoryTreeIds", key = "#categoryId")
+    public List<Long> getCategoryAndAllChildrenIds(Long categoryId) {
+        Category category = findByIdWithChildren(categoryId);
+        List<Long> ids = new ArrayList<>();
+        collectCategoryIds(category, ids);
+        return ids;
+    }
+
+    private void collectCategoryIds(Category category, List<Long> ids) {
+        ids.add(category.getId());
+        if (category.getChildren() != null && !category.getChildren().isEmpty()) {
+            for (Category child : category.getChildren()) {
+                collectCategoryIds(child, ids);
+            }
+        }
     }
 }

--- a/src/main/java/com/tryiton/core/product/service/ProductService.java
+++ b/src/main/java/com/tryiton/core/product/service/ProductService.java
@@ -32,36 +32,38 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final TagRepository tagRepository;
     private final WishlistRepository wishlistRepository;
-    private final CategoryRepository categoryRepository;
+    private final CategoryService categoryService;
     private final RecommendBehaviorLogService recommendBehaviorLogService;
 
-    @Cacheable(value = "productDetail", key = "'product:' + #productId", unless = "#result == null")
+    @Cacheable(value = "productDetail", key = "{'user:' + #userId, 'product:' + #productId}", unless = "#result == null")
     public ProductDetailResponseDto getProductDetail(Long userId, Long productId) {
-        Product product = productRepository.findByIdWithCategoryAndVariants(productId)
-            .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND,
-                "ID " + productId + "에 해당하는 상품을 찾을 수 없습니다."));
+        Object[] result = productRepository.findProductWithLikeStatus(userId, productId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND,
+                        "ID " + productId + "에 해당하는 상품을 찾을 수 없습니다."));
 
-        boolean liked = userId != null && 
-            wishlistRepository.existsByUserIdAndProductId(userId, productId);
+        Product product = (Product) result[0];
+        boolean liked = (boolean) result[1];
 
         List<ProductVariantDto> variantDto = product.getVariants().stream()
-            .map(ProductVariantDto::new)
-            .toList();
+                .map(ProductVariantDto::new)
+                .toList();
 
-        if(userId != null) {
+        if (userId != null) {
             recommendBehaviorLogService.logUserAction(userId, productId, RecommendAction.CLICK);
         }
 
         return new ProductDetailResponseDto(product, variantDto, liked);
     }
 
-    @Cacheable(value = "categoryProducts", key = "'category:' + #category.id + ':page:' + #page + ':size:' + #size")
+    @Cacheable(value = "categoryProducts", key = "{'category:' + #category.id, 'user:' + #userId, 'page:' + #page, 'size:' + #size}")
     public Page<ProductSummaryDto> getProductsByCategory(Long userId, Category category, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size, 
-            Sort.by("wishlistCount").descending().and(Sort.by("createAt").descending()));
+        Pageable pageable = PageRequest.of(page, size,
+                Sort.by("wishlistCount").descending().and(Sort.by("createAt").descending()));
 
-        Page<ProductSummaryDto> products = productRepository.findSummaryByCategoryHierarchy(
-            category.getId(), pageable);
+        List<Long> categoryIds = categoryService.getCategoryAndAllChildrenIds(category.getId());
+
+        Page<ProductSummaryDto> products = productRepository.findSummaryByCategoryIds(
+                categoryIds, pageable);
 
         if (products == null || !products.hasContent()) {
             return Page.empty();
@@ -69,7 +71,9 @@ public class ProductService {
 
         if (userId != null) {
             Set<Long> likedProductIds = new HashSet<>(
-                wishlistRepository.findProductIdsByUserId(userId));
+                    wishlistRepository.findProductIdsByUserId(products.stream()
+                            .map(ProductSummaryDto::getId)
+                            .collect(Collectors.toList()), userId));
             products.forEach(dto -> dto.setLiked(likedProductIds.contains(dto.getId())));
         }
 


### PR DESCRIPTION
   1. : 특정 카테고리 및 모든 하위 카테고리의 ID 목록을 조회하는 효율적인 로직을 추가했습니다.
   2. :
       * 비효율적인 OR 조건의 계층 쿼리를, 인덱스를 잘 활용하는 IN 조건 쿼리로 교체했습니다.
       * 상품 상세 정보와 '좋아요' 여부를 한 번의 쿼리로 가져오도록 하여 N+1 문제를 해결했습니다.
   3. : 위 두 서비스와 리포지토리의 최적화된 메소드를 사용하도록 로직을 모두 변경했습니다.
