### PR TITLE
fix: 상품 및 스토리 API 성능 개선 및 주요 버그 수정 #109

### DIFF
--- a/src/main/java/com/tryiton/core/product/repository/ProductRepository.java
+++ b/src/main/java/com/tryiton/core/product/repository/ProductRepository.java
@@ -70,13 +70,17 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Page<ProductSummaryDto> findSummaryByCategoryIds(@Param("categoryIds") List<Long> categoryIds, Pageable pageable);
 
     // 상품 상세 정보와 '좋아요' 여부를 한 번의 쿼리로 조회 (N+1 문제 해결)
-    @Query("SELECT p, CASE WHEN w.id IS NOT NULL THEN true ELSE false END " +
-            "FROM Product p " +
-            "LEFT JOIN p.category " +
-            "LEFT JOIN FETCH p.variants " +
-            "LEFT JOIN WishlistItem w ON w.product = p AND w.wishlist.user.id = :userId " +
-            "WHERE p.id = :productId AND p.deleted = false")
-    Optional<Object[]> findProductWithLikeStatus(@Param("userId") Long userId, @Param("productId") Long productId);
+//    @Query("SELECT p, CASE WHEN w.id IS NOT NULL THEN true ELSE false END " +
+//            "FROM Product p " +
+//            "LEFT JOIN p.category " +
+//            "LEFT JOIN FETCH p.variants " +
+//            "LEFT JOIN WishlistItem w ON w.product = p AND w.wishlist.user.id = :userId " +
+//            "WHERE p.id = :productId AND p.deleted = false")
+//    Optional<Object[]> findProductWithLikeStatus(@Param("userId") Long userId, @Param("productId") Long productId);
+
+    // N+1 쿼리 해결: 상품 상세 조회 시 category와 variants를 함께 조회
+    @Query("SELECT p FROM Product p JOIN FETCH p.category LEFT JOIN FETCH p.variants WHERE p.id = :id AND p.deleted = false")
+    Optional<Product> findByIdWithDetails(@Param("id") Long id);
     
     // 시드 기반 랜덤 정렬로 페이지네이션 지원
     @Query(value = "SELECT * FROM product WHERE deleted = false AND category_id IN " +

--- a/src/main/java/com/tryiton/core/product/service/ProductService.java
+++ b/src/main/java/com/tryiton/core/product/service/ProductService.java
@@ -37,12 +37,14 @@ public class ProductService {
 
     @Cacheable(value = "productDetail", key = "{'user:' + #userId, 'product:' + #productId}", unless = "#result == null")
     public ProductDetailResponseDto getProductDetail(Long userId, Long productId) {
-        Object[] result = productRepository.findProductWithLikeStatus(userId, productId)
+        Product product = productRepository.findByIdWithDetails(productId)
                 .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND,
                         "ID " + productId + "에 해당하는 상품을 찾을 수 없습니다."));
 
-        Product product = (Product) result[0];
-        boolean liked = (boolean) result[1];
+        boolean liked = false;
+        if (userId != null) {
+            liked = wishlistRepository.existsByUserIdAndProductId(userId, productId);
+        }
 
         List<ProductVariantDto> variantDto = product.getVariants().stream()
                 .map(ProductVariantDto::new)

--- a/src/main/java/com/tryiton/core/story/repository/CommentRepository.java
+++ b/src/main/java/com/tryiton/core/story/repository/CommentRepository.java
@@ -5,10 +5,15 @@ import com.tryiton.core.story.entity.Story;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Optional<Comment> findById(Long commentId);
     List<Comment> findByStory(Story story);
     Optional<Comment> findByIdAndStory(Long commentId, Story story);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.author WHERE c.story.id IN :storyIds")
+    List<Comment> findByStoryIdIn(@Param("storyIds") List<Long> storyIds);
 }

--- a/src/main/java/com/tryiton/core/story/service/StoryService.java
+++ b/src/main/java/com/tryiton/core/story/service/StoryService.java
@@ -17,12 +17,14 @@ import com.tryiton.core.story.dto.StoryResponseDto;
 import com.tryiton.core.story.entity.Story;
 import com.tryiton.core.story.repository.StoryLikeRepository;
 import com.tryiton.core.story.repository.StoryRepository;
+import com.tryiton.core.story.repository.CommentRepository;
 import com.tryiton.core.story.dto.StoriesSummaryResponseDto;
 import com.tryiton.core.story.dto.StorySummaryDto;
 import com.tryiton.core.wishlist.repository.WishlistRepository;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -44,6 +46,7 @@ public class StoryService {
     private final ClosetAvatarRepository closetAvatarRepository;
     private final WishlistRepository wishlistRepository;
     private final StoryLikeRepository storyLikeRepository;
+    private final CommentRepository commentRepository;
     private final WebClient userServiceWebClient;
 
     @Value("${cloud.aws.s3.bucket}")
@@ -54,11 +57,12 @@ public class StoryService {
 
     public StoryService(StoryRepository storyRepository, ClosetAvatarRepository closetAvatarRepository,
         WishlistRepository wishlistRepository, StoryLikeRepository storyLikeRepository,
-        WebClient userServiceWebClient) {
+        CommentRepository commentRepository, WebClient userServiceWebClient) {
         this.storyRepository = storyRepository;
         this.closetAvatarRepository = closetAvatarRepository;
         this.wishlistRepository = wishlistRepository;
         this.storyLikeRepository = storyLikeRepository;
+        this.commentRepository = commentRepository;
         this.userServiceWebClient = userServiceWebClient;
     }
 
@@ -314,64 +318,67 @@ public class StoryService {
     }
 
     private StoriesResponseDto mapToStoriesResponseDto(List<Story> stories, Long currentUserId) {
-        Set<Long> likedStoryIds = Collections.emptySet();
-        Set<Long> wishlistedProductIds = Collections.emptySet();
-
-        if (currentUserId != null && !stories.isEmpty()) {
-            List<Long> storyIds = stories.stream().map(Story::getId).collect(Collectors.toList());
-            likedStoryIds = storyLikeRepository.findStoryIdsByMemberIdAndStoryIdsIn(currentUserId, storyIds);
-
-            List<Long> productIds = stories.stream()
-                    .flatMap(s -> s.getClosetAvatar().getItems().stream())
-                    .map(item -> item.getProduct().getId())
-                    .collect(Collectors.toList());
-            
-            if (!productIds.isEmpty()) {
-                wishlistedProductIds = wishlistRepository.findProductIdsByMemberIdAndProductIdsIn(currentUserId, productIds);
-            }
+        if (stories.isEmpty()) {
+            return StoriesResponseDto.builder().stories(Collections.emptyList()).length(0).build();
         }
 
-        Set<Long> finalLikedStoryIds = likedStoryIds;
-        Set<Long> finalWishlistedProductIds = wishlistedProductIds;
+        List<Long> storyIds = stories.stream().map(Story::getId).collect(Collectors.toList());
 
-        List<StoryResponseDto> storyResponseDtos = stories.stream()
-            .map(story -> {
-                AuthorDto author = story.getAuthor() != null ? AuthorDto.builder()
-                        .id(story.getAuthor().getId())
-                        .username(story.getAuthor().getUsername())
-                        .profileImageUrl(story.getAuthor().getProfile() != null ? story.getAuthor().getProfile().getProfileImageUrl() : null)
-                        .build() : null;
+        Set<Long> likedStoryIds = (currentUserId != null) ?
+                storyLikeRepository.findStoryIdsByMemberIdAndStoryIdsIn(currentUserId, storyIds) :
+                Collections.emptySet();
 
-                List<ProductResponseDto> productResponseDtos = story.getClosetAvatar() != null && story.getClosetAvatar().getItems() != null ?
-                        story.getClosetAvatar().getItems().stream()
-                                .filter(avatarItem -> avatarItem.getProduct() != null)
-                                .map(avatarItem -> new ProductResponseDto(avatarItem.getProduct(), finalWishlistedProductIds.contains(avatarItem.getProduct().getId())))
-                                .collect(Collectors.toList()) : Collections.emptyList();
+        List<Long> productIds = stories.stream()
+                .flatMap(s -> s.getClosetAvatar().getItems().stream())
+                .map(item -> item.getProduct().getId())
+                .collect(Collectors.toList());
 
-                List<CommentResponseDto> comments = story.getComments() != null ?
-                        story.getComments().stream()
-                                .map(comment -> CommentResponseDto.builder()
+        Set<Long> wishlistedProductIds = (currentUserId != null && !productIds.isEmpty()) ?
+                wishlistRepository.findProductIdsByMemberIdAndProductIdsIn(currentUserId, productIds) :
+                Collections.emptySet();
+
+        Map<Long, List<CommentResponseDto>> commentsMap = commentRepository.findByStoryIdIn(storyIds).stream()
+                .collect(Collectors.groupingBy(
+                        comment -> comment.getStory().getId(),
+                        Collectors.mapping(
+                                comment -> CommentResponseDto.builder()
                                         .id(comment.getId())
                                         .username(comment.getAuthor() != null ? comment.getAuthor().getUsername() : null)
                                         .contents(comment.getContents())
                                         .position(comment.getPosition())
                                         .createdAt(comment.getCreatedAt())
-                                        .build())
-                                .collect(Collectors.toList()) : Collections.emptyList();
+                                        .build(),
+                                Collectors.toList()
+                        )
+                ));
 
-                return StoryResponseDto.builder()
-                        .storyId(story.getId())
-                        .storyImageUrl(story.getStoryImageUrl())
-                        .contents(story.getContents())
-                        .likeCount(story.getLikeCount())
-                        .liked(finalLikedStoryIds.contains(story.getId()))
-                        .createdAt(story.getCreatedAt())
-                        .products(productResponseDtos)
-                        .author(author)
-                        .comments(comments)
-                        .build();
-            })
-            .collect(Collectors.toList());
+        List<StoryResponseDto> storyResponseDtos = stories.stream()
+                .map(story -> {
+                    AuthorDto author = story.getAuthor() != null ? AuthorDto.builder()
+                            .id(story.getAuthor().getId())
+                            .username(story.getAuthor().getUsername())
+                            .profileImageUrl(story.getAuthor().getProfile() != null ? story.getAuthor().getProfile().getProfileImageUrl() : null)
+                            .build() : null;
+
+                    List<ProductResponseDto> productResponseDtos = story.getClosetAvatar() != null && story.getClosetAvatar().getItems() != null ?
+                            story.getClosetAvatar().getItems().stream()
+                                    .filter(avatarItem -> avatarItem.getProduct() != null)
+                                    .map(avatarItem -> new ProductResponseDto(avatarItem.getProduct(), wishlistedProductIds.contains(avatarItem.getProduct().getId())))
+                                    .collect(Collectors.toList()) : Collections.emptyList();
+
+                    return StoryResponseDto.builder()
+                            .storyId(story.getId())
+                            .storyImageUrl(story.getStoryImageUrl())
+                            .contents(story.getContents())
+                            .likeCount(story.getLikeCount())
+                            .liked(likedStoryIds.contains(story.getId()))
+                            .createdAt(story.getCreatedAt())
+                            .products(productResponseDtos)
+                            .author(author)
+                            .comments(commentsMap.getOrDefault(story.getId(), Collections.emptyList()))
+                            .build();
+                })
+                .collect(Collectors.toList());
 
         return StoriesResponseDto.builder()
                 .stories(storyResponseDtos)


### PR DESCRIPTION
## 작업 내용 (요약)
  상품 카테고리 조회 API와 스토리 피드 API에서 발생하던 심각한 성능 병목 현상을 해결하고, 상품 상세 페이지와 스토리 피드에서 발생하던 버그를 수정했습니다. N+1 쿼리 문제를 해결하고 불필요한 DB 조회를 최소화하여 애플리케이션의 전반적인 안정성과 응답 속도를 개선했습니다.

  ---

##  1. 상품 카테고리 API 성능 최적화

###  문제 원인 (Before)
   - N+1 쿼리 문제: 상품 목록을 조회한 후, 각 상품의 '좋아요' 여부를 확인하기 위해 추가 쿼리가 발생하여 DB 부하를 가중시켰습니다.
   - 비효율적인 쿼리: 재귀 쿼리를 사용했음에도 불구하고, 여러 번의 데이터 변환 과정과 추가 쿼리로 인해 성능 저하가 발생했습니다.
   - 결과: 부하 테스트 시 DB CPU 사용량이 100%에 도달하고, 대부분의 요청이 타임아웃되는 등 서비스 불능 상태에 가까운 성능을 보였습니다.

###  해결 방안 (After)
   - 단일 통합 쿼리 도입:
       - WITH RECURSIVE 구문과 LEFT JOIN을 결합한 단일 네이티브 쿼리를 구현했습니다.
       - 이 쿼리는 카테고리 계층 구조, 상품 정보, 사용자별 '좋아요' 여부를 모두 한 번의 DB 조회로 가져옵니다.
       - 서비스 로직에서 데이터를 조합하던 과정을 제거하여 애플리케이션 부하를 줄이고 로직을 단순화했습니다.
   - 타입 변환 오류 수정: 네이티브 쿼리 결과를 DTO로 변환하는 과정에서 발생하던 NullPointerException 및 ClassCastException을 해결하여 안정성을 확보했습니다.

##  2. 상품 상세 페이지 API 버그 수정

###  문제 원인 (Before)
   - `ClassCastException` 발생: 상품 상세 정보를 조회하는 Repository 메서드가 Product 엔티티가 아닌 Object[]를 반환하여, 서비스 로직에서 타입 변환에 실패하고 애플리케이션 크래시가 발생했습니다.

###  해결 방안 (After)
   - 전용 조회 메서드 추가: JOIN FETCH를 사용하여 상품의 연관관계(variants, category)를 함께 조회하는 findByIdWithDetails 메서드를
     ProductRepository에 추가했습니다.
   - 서비스 로직 수정: ProductService가 이 새로운 메서드를 사용하도록 변경하고, '좋아요' 여부는 별도의 쿼리로 안전하게 확인하도록 수정하여 타입 불일치 문제를 해결했습니다.

##  3. 스토리 피드 API 버그 수정 및 성능 최적화

###  문제 원인 (Before)
   - 댓글 누락 버그: 스토리 피드 조회 시, DB에서 댓글 데이터를 조회했음에도 불구하고 최종 응답 DTO에 포함되지 않는 버그가 있었습니다.
   - N+1 쿼리 문제: 각 스토리마다 댓글 목록과 '좋아요' 여부를 확인하기 위해 별도의 쿼리가 실행되어 불필요한 DB 조회가 발생했습니다.

###  해결 방안 (After)
   - 댓글 데이터 매핑 로직 수정: StoryService에서 조회된 댓글 목록을 storyId 기준으로 그룹화하여 각 스토리에 맞게 정확히 매핑하도록 수정하여 댓글 누락 버그를 해결했습니다.
   - N+1 쿼리 해결: findByStoryIdIn과 같은 메서드를 활용하여 여러 스토리에 대한 댓글과 '좋아요' 정보를 한 번의 쿼리로 가져오도록 최적화했습니다.

##  기대 효과
   - DB 부하 감소: 불필요한 쿼리 제거로 DB CPU 사용량이 크게 감소하고 안정적으로 유지됩니다.
   - 응답 속도 향상: API 응답 시간이 획기적으로 단축되고, 부하 상황에서도 타임아웃 문제가 해결됩니다.
   - 안정성 향상: 여러 ClassCastException 및 버그를 해결하여 애플리케이션 안정성을 높였습니다.

