### PR TITLE
refactor: 캐시 전략 분리 및 DTO 수정으로 RDS 부하 문제 해결

### DIFF
--- a/src/main/java/com/tryiton/core/product/dto/ProductHierarchyDto.java
+++ b/src/main/java/com/tryiton/core/product/dto/ProductHierarchyDto.java
@@ -7,17 +7,21 @@ import java.time.LocalDateTime;
 @Getter
 public class ProductHierarchyDto {
     @JsonProperty("id")
-    private final Long productId;
-    private final String productName;
-    private final String img1;
-    private final Integer price;
-    private final Integer sale;
-    private final String brand;
-    private final Long wishlistCount;
-    private final LocalDateTime createAt;
-    private final Long categoryId;
-    private final String categoryName;
-    private final Boolean isLiked;
+    private Long productId;
+    private String productName;
+    private String img1;
+    private Integer price;
+    private Integer sale;
+    private String brand;
+    private Long wishlistCount;
+    private LocalDateTime createAt;
+    private Long categoryId;
+    private String categoryName;
+    private Boolean isLiked;
+
+    public void setIsLiked(boolean isLiked) {
+        this.isLiked = isLiked;
+    }
 
     public ProductHierarchyDto(
         Number productId, String productName, String img1,

--- a/src/main/java/com/tryiton/core/product/service/ProductService.java
+++ b/src/main/java/com/tryiton/core/product/service/ProductService.java
@@ -57,12 +57,29 @@ public class ProductService {
         return new ProductDetailResponseDto(product, variantDto, liked);
     }
 
-    @Cacheable(value = "hierarchicalCategoryProducts", key = "{#categoryId, #userId, #page, #size}")
     public Page<ProductHierarchyDto> getProductsByCategory(Long userId, Long categoryId, int page, int size) {
+        Page<ProductHierarchyDto> products = getPublicProductsByCategory(categoryId, page, size);
+
+        if (userId != null) {
+            List<Long> productIds = products.getContent().stream()
+                    .map(ProductHierarchyDto::getProductId)
+                    .collect(Collectors.toList());
+
+            if (!productIds.isEmpty()) {
+                Set<Long> likedProductIds = new HashSet<>(wishlistRepository.findProductIdsByUserIdAndProductIds(userId, productIds));
+                products.getContent().forEach(p -> p.setIsLiked(likedProductIds.contains(p.getProductId())));
+            }
+        }
+        return products;
+    }
+
+    @Cacheable(value = "hierarchicalCategoryProducts", key = "{#categoryId, #page, #size}")
+    public Page<ProductHierarchyDto> getPublicProductsByCategory(Long categoryId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size,
                 Sort.by("wishlist_count").descending().and(Sort.by("create_at").descending()));
 
-        Page<Object[]> results = productRepository.findHierarchyByCategoryRaw(userId, categoryId, pageable);
+        // userId를 null로 전달하여 '찜' 여부는 기본값(false)으로 조회
+        Page<Object[]> results = productRepository.findHierarchyByCategoryRaw(null, categoryId, pageable);
 
         return results.map(obj -> new ProductHierarchyDto(
                 (Number) obj[0],

--- a/src/main/java/com/tryiton/core/story/service/StoryService.java
+++ b/src/main/java/com/tryiton/core/story/service/StoryService.java
@@ -334,7 +334,7 @@ public class StoryService {
                 .collect(Collectors.toList());
 
         Set<Long> wishlistedProductIds = (currentUserId != null && !productIds.isEmpty()) ?
-                wishlistRepository.findProductIdsByMemberIdAndProductIdsIn(currentUserId, productIds) :
+                new java.util.HashSet<>(wishlistRepository.findProductIdsByUserIdAndProductIds(currentUserId, productIds)) :
                 Collections.emptySet();
 
         Map<Long, List<CommentResponseDto>> commentsMap = commentRepository.findByStoryIdIn(storyIds).stream()

--- a/src/main/java/com/tryiton/core/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/tryiton/core/wishlist/repository/WishlistRepository.java
@@ -23,5 +23,5 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
     boolean existsByUserIdAndProductId(@Param("userId") Long userId, @Param("productId") Long productId);
 
     @Query("SELECT wi.product.id FROM WishlistItem wi WHERE wi.wishlist.user.id = :userId AND wi.product.id IN :productIds")
-    Set<Long> findProductIdsByMemberIdAndProductIdsIn(@Param("userId") Long userId, @Param("productIds") List<Long> productIds);
+    List<Long> findProductIdsByUserIdAndProductIds(@Param("userId") Long userId, @Param("productIds") List<Long> productIds);
 }


### PR DESCRIPTION

##  문제 상황 (Problem)

  프로덕션 환경에서 제품 카테고리 조회 API에 대한 부하 테스트 시, 다음과 같은 심각한 성능 문제가 발생했습니다.

   - RDS CPU 사용량 99%: WITH RECURSIVE를 사용하는 무거운 SQL 쿼리가 매 요청마다 실행되어 RDS에 과도한 부하를 유발했습니다.
   - Request Timeout: DB 응답 지연으로 인해 애플리케이션의 커넥션 풀이 고갈되었고, 결국 다수의 요청이 타임아웃되는 현상이 발생했습니다.

--- 
## 원인 분석 및 해결 과정

  문제 해결을 위해 여러 단계의 분석과 수정을 진행했습니다.

---

###  1. 캐시 저장 실패: `LazyInitializationException`

   - 원인 분석: 최초 진단 결과, 캐시가 전혀 동작하지 않고 있었습니다. 로그 분석 결과, Category 엔티티의 재귀적인 children 필드를 직렬화하는
     과정에서 지연 로딩(Lazy Loading)으로 인해 LazyInitializationException이 발생하여 Redis에 캐시 저장을 실패하는 것을 확인했습니다.
   - 해결: 엔티티를 직접 캐싱하는 대신, 필요한 데이터만 담는 DTO 프로젝션(ProductHierarchyDto)을 도입했습니다. 리포지토리에서 네이티브 쿼리  결과를 DTO로 직접 반환하도록 수정하여 직렬화 문제를 원천적으로 해결했습니다.

###  2. 런타임 오류 발생: `Type Mismatch` & `NullPointerException`

   - 테스트 제약: DTO 프로젝션을 도입하는 과정에서, DB가 반환하는 컬럼의 실제 타입(BigInteger, Timestamp)과 DTO 생성자가 기대하는 Java 타입(Long, LocalDateTime)이 달라 argument type mismatch 오류가 발생했습니다. 또한, create_at과 같이 null이 가능한 컬럼을 처리하지 않아  NullPointerException이 발생했습니다.
   - 해결: DTO 생성자가 Number, java.sql.Timestamp 등 DB에서 반환될 수 있는 다양한 타입을 파라미터로 받도록 수정했습니다. 생성자 내부에서  null-safe한 로직을 통해 최종적으로 원하는 Java 타입으로 안전하게 변환하도록 하여 런타임 안정성을 확보했습니다.

###  3. 비효율적인 캐시 전략: `userId`로 인한 캐시 파편화

   - 원인 분석: 캐시 저장이 성공한 후에도 부하 테스트 시 성능 개선이 이루어지지 않았습니다. 원인은 캐시 키에 userId가 포함되어, 사용자별로 별도의 캐시가 생성되었기 때문입니다. 이는 수백 명의 가상 유저가 동시에 요청하는 테스트 환경에서 캐시 히트율을 0에 가깝게 만들어 사실상 캐시가 없는 것과 동일한 결과를 초래했습니다.
   - 해결: 캐싱 전략을 분리하여 이 문제를 해결했습니다.
       1. 공통 데이터 캐싱: userId를 제외한 공통 제품 목록을 조회하는 내부 메소드(getPublicProductsByCategory)를 만들고, 이 메소드의 결과를 캐싱하여 모든 사용자가 공유하도록 했습니다.
       2. 사용자별 데이터 후처리: 캐시된 공통 목록을 가져온 뒤, 로그인한 사용자의 '찜' 정보만 가볍고 효율적인 IN 쿼리로 조회하여 메모리에서 추가로 반영하도록 로직을 변경했습니다.

###  4. 연쇄적인 문제 해결

   - 프론트엔드 호환성: 백엔드 DTO의 필드명을 productId로 변경하면서 발생한 프론트엔드 detail/undefined 오류는, @JsonProperty("id") 어노테이션을 사용하여 API 응답 JSON은 기존 형식을 유지하도록 하여 해결했습니다.
   - 컴파일 오류: WishlistRepository의 메소드 시그니처 변경으로 인해 StoryService에서 발생한 컴파일 오류를 찾아 수정하여 코드 전체의 정합성을 맞췄습니다.

---
##  결과 (Result)

  이번 리팩토링을 통해, 무거운 DB 쿼리는 사용자 전체에 걸쳐 효율적으로 캐시되고, 사용자별 데이터는 가벼운 쿼리로 후처리되도록 개선되었습니다.
  이를 통해 RDS의 부하를 획기적으로 줄이고, API 응답 시간을 단축하여 시스템 안정성을 확보했습니다.