### PR TITLE
refactor: 캐시 대상을 ID 목록으로 변경 및 메모리 페이지네이션 적용

### DIFF
--- a/src/main/java/com/tryiton/core/product/dto/ProductHierarchyDto.java
+++ b/src/main/java/com/tryiton/core/product/dto/ProductHierarchyDto.java
@@ -24,21 +24,22 @@ public class ProductHierarchyDto {
     }
 
     public ProductHierarchyDto(
-        Number productId, String productName, String img1,
+        Long productId, String productName, String img1,
         Integer price, Integer sale, String brand,
-        Number wishlistCount, java.sql.Timestamp createAt,
-        Number categoryId, String categoryName, Number isLiked
+        Integer wishlistCount, // Long -> Integer로 변경
+        LocalDateTime createAt,
+        Long categoryId, String categoryName, Integer isLiked
     ) {
-        this.productId = productId.longValue();
+        this.productId = productId;
         this.productName = productName;
         this.img1 = img1;
         this.price = price;
         this.sale = sale;
         this.brand = brand;
-        this.wishlistCount = wishlistCount.longValue();
-        this.createAt = (createAt != null) ? createAt.toLocalDateTime() : null;
-        this.categoryId = categoryId.longValue();
+        this.wishlistCount = wishlistCount != null ? wishlistCount.longValue() : 0L; // 내부에서 Long으로 변환
+        this.createAt = createAt;
+        this.categoryId = categoryId;
         this.categoryName = categoryName;
-        this.isLiked = isLiked.intValue() == 1;
+        this.isLiked = isLiked != null && isLiked == 1;
     }
 }

--- a/src/main/java/com/tryiton/core/product/repository/ProductRepository.java
+++ b/src/main/java/com/tryiton/core/product/repository/ProductRepository.java
@@ -1,5 +1,6 @@
 package com.tryiton.core.product.repository;
 
+import com.tryiton.core.product.dto.ProductHierarchyDto;
 import com.tryiton.core.product.dto.ProductSummaryDto;
 import com.tryiton.core.product.entity.Category;
 import com.tryiton.core.product.entity.Product;
@@ -148,29 +149,25 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             """, nativeQuery = true)
     List<Object[]> findTop4ProductsPerCategory();
 
-    // 카테고리 계층 구조와 찜 여부를 한 번의 재귀 쿼리로 조회하여 성능 최적화
     @Query(value = "WITH RECURSIVE category_tree AS ( " +
             "  SELECT category_id FROM category WHERE category_id = :categoryId " +
             "  UNION ALL " +
             "  SELECT c.category_id FROM category c JOIN category_tree ct ON c.parent_category_id = ct.category_id " +
             ") " +
-            "SELECT p.product_id, p.product_name, p.img1, p.price, p.sale, p.brand, p.wishlist_count, p.create_at, p.category_id, c.category_name, " +
-            "CASE WHEN w.wishlist_item_id IS NOT NULL THEN 1 ELSE 0 END " +
+            "SELECT p.product_id " +
             "FROM product p " +
             "JOIN category_tree ct ON p.category_id = ct.category_id " +
-            "JOIN category c ON p.category_id = c.category_id " +
-            "LEFT JOIN wishlist_item w ON w.product_id = p.product_id AND w.wishlist_id = (SELECT ww.wishlist_id FROM wishlist ww WHERE ww.user_id = :userId) " +
-            "WHERE p.deleted = false",
-            countQuery = "WITH RECURSIVE category_tree AS ( " +
-                    "  SELECT category_id FROM category WHERE category_id = :categoryId " +
-                    "  UNION ALL " +
-                    "  SELECT c.category_id FROM category c JOIN category_tree ct ON c.parent_category_id = ct.category_id " +
-                    ") " +
-                    "SELECT count(p.product_id) FROM product p JOIN category_tree ct ON p.category_id = ct.category_id WHERE p.deleted = false",
+            "WHERE p.deleted = false " +
+            "ORDER BY p.wishlist_count DESC, p.create_at DESC",
             nativeQuery = true)
-    Page<Object[]> findHierarchyByCategoryRaw(
-            @Param("userId") Long userId,
-            @Param("categoryId") Long categoryId,
-            Pageable pageable
-    );
+    List<Long> findSortedProductIdsByHierarchicalCategory(@Param("categoryId") Long categoryId);
+
+    @Query("SELECT new com.tryiton.core.product.dto.ProductHierarchyDto(" +
+            "p.id, p.productName, p.img1, p.price, p.sale, p.brand, p.wishlistCount, p.createAt, p.category.id, p.category.categoryName, " +
+            "CASE WHEN w.id IS NOT NULL THEN 1 ELSE 0 END) " +
+            "FROM Product p " +
+            "JOIN p.category c " +
+            "LEFT JOIN WishlistItem w ON w.product.id = p.id AND w.wishlist.user.id = :userId " +
+            "WHERE p.id IN :productIds")
+    List<ProductHierarchyDto> findProductDetailsByProductIds(@Param("userId") Long userId, @Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/tryiton/core/product/service/ProductService.java
+++ b/src/main/java/com/tryiton/core/product/service/ProductService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -58,42 +59,35 @@ public class ProductService {
     }
 
     public Page<ProductHierarchyDto> getProductsByCategory(Long userId, Long categoryId, int page, int size) {
-        Page<ProductHierarchyDto> products = getPublicProductsByCategory(categoryId, page, size);
+        // 1. 캐시된 전체 상품 ID 목록을 가져옴
+        List<Long> allProductIds = getSortedProductIdsForCategory(categoryId);
 
-        if (userId != null) {
-            List<Long> productIds = products.getContent().stream()
-                    .map(ProductHierarchyDto::getProductId)
-                    .collect(Collectors.toList());
+        // 2. 메모리에서 페이지네이션 수행
+        Pageable pageable = PageRequest.of(page, size);
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), allProductIds.size());
 
-            if (!productIds.isEmpty()) {
-                Set<Long> likedProductIds = new HashSet<>(wishlistRepository.findProductIdsByUserIdAndProductIds(userId, productIds));
-                products.getContent().forEach(p -> p.setIsLiked(likedProductIds.contains(p.getProductId())));
-            }
+        if (start >= allProductIds.size()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, allProductIds.size());
         }
-        return products;
+        List<Long> pagedProductIds = allProductIds.subList(start, end);
+
+        // 3. 현재 페이지의 상품 상세 정보만 DB에서 조회
+        List<ProductHierarchyDto> products = productRepository.findProductDetailsByProductIds(userId, pagedProductIds);
+
+        // 4. DB에서 조회된 결과는 정렬되어 있지 않으므로, 원래 ID 목록의 순서대로 정렬
+        Map<Long, ProductHierarchyDto> productMap = products.stream()
+                .collect(Collectors.toMap(ProductHierarchyDto::getProductId, p -> p));
+        List<ProductHierarchyDto> sortedProducts = pagedProductIds.stream()
+                .map(productMap::get)
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(sortedProducts, pageable, allProductIds.size());
     }
 
-    @Cacheable(value = "hierarchicalCategoryProducts", key = "{#categoryId, #page, #size}")
-    public Page<ProductHierarchyDto> getPublicProductsByCategory(Long categoryId, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size,
-                Sort.by("wishlist_count").descending().and(Sort.by("create_at").descending()));
-
-        // userId를 null로 전달하여 '찜' 여부는 기본값(false)으로 조회
-        Page<Object[]> results = productRepository.findHierarchyByCategoryRaw(null, categoryId, pageable);
-
-        return results.map(obj -> new ProductHierarchyDto(
-                (Number) obj[0],
-                (String) obj[1],
-                (String) obj[2],
-                (Integer) obj[3],
-                (Integer) obj[4],
-                (String) obj[5],
-                (Number) obj[6],
-                (java.sql.Timestamp) obj[7],
-                (Number) obj[8],
-                (String) obj[9],
-                (Number) obj[10]
-        ));
+    @Cacheable(value = "sortedCategoryProductIds", key = "#categoryId")
+    public List<Long> getSortedProductIdsForCategory(Long categoryId) {
+        return productRepository.findSortedProductIdsByHierarchicalCategory(categoryId);
     }
 
     @Cacheable(value = "mainProducts", key = "'main:products'", unless = "#result == null")


### PR DESCRIPTION
##  문제 상황 (Problem)

   - 현상: 제품 카테고리 조회 API(GET /products/category)가 부하 테스트 시 RDS CPU 사용량을 99%까지 폭증시키며 대규모 Request Timeout을 유발,
     사실상 서버 다운으로 이어졌습니다.
   - 원인: 비용이 매우 높은 WITH RECURSIVE 쿼리가 캐시되지 않고 반복적으로 실행되는 것이 원인이었습니다. 심층 분석 결과, 아래와 같은 세 가지 복합적인 문제가 발견되었습니다.
       1. 캐시 저장 실패: JPA 엔티티의 지연 로딩(Lazy Loading) 특성으로 인해 캐시 직렬화(Serialization)가 실패했습니다.
       2. 비효율적인 캐시 키: userId를 캐시 키에 포함하여 사용자별로 캐시가 파편화되어 재사용률이 0에 수렴했습니다.
       3. 구조적 캐싱 한계: page 번호를 캐시 키에 포함하여, 페이지별로 캐시가 분리되었습니다. 이로 인해 동시 요청 시 페이지 수만큼 무거운 쿼리가 동시에 실행되는 'Thundering Herd' 문제가 발생했습니다.

--- 

##  해결 방안 (Solution)

  '페이지별 데이터'를 캐싱하던 기존 전략을 폐기하고, "카테고리별 정렬된 전체 상품 ID 목록"을 캐싱한 후 애플리케이션에서 후처리하는 새로운 2단계  캐시 전략을 도입했습니다.

   1. 전체 ID 목록 캐싱 (1단계 캐시):
       - 비용이 가장 높은 WITH RECURSIVE 쿼리를 사용하여, 특정 카테고리에 속한 모든 상품의 ID를 정렬된 상태(List<Long>)로 가져오는
         findSortedProductIdsByHierarchicalCategory 메소드를 ProductRepository에 추가했습니다.
       - 이 ID 목록 전체를 sortedCategoryProductIds라는 이름으로 캐싱하는 getSortedProductIdsForCategory 메소드를 ProductService에 구현했습니다. 이 메소드는 카테고리당 단 한 번만 DB를 호출합니다.

   2. 메모리 페이지네이션 및 상세 정보 조회 (후처리):
       - getProductsByCategory 메소드는 이제 다음과 같은 역할을 수행합니다.
           - 캐시된 전체 상품 ID 목록을 가져옵니다.
           - 애플리케이션 메모리에서 페이지네이션을 수행하여 현재 페이지에 해당하는 ID 목록만 추출합니다. (subList)
           - 추출된 ID 목록을 사용하여, 가볍고 빠른 IN 쿼리로 제품의 상세 정보만 조회하는 findProductDetailsByProductIds 메소드를 호출합니다.
           - 이 과정에서 사용자별 '찜' 정보도 함께 처리하여 최종 Page<ProductHierarchyDto> 객체를 생성합니다.

##  기대 효과

   - RDS 부하 해결: 가장 무거운 재귀 쿼리는 카테고리당 단 한 번만 실행되어 그 결과(ID 목록)가 캐시되므로, RDS CPU 부하가 획기적으로 감소하고 안정성이 확보됩니다.
   - 응답 속도 향상: 대부분의 페이지 요청은 캐시된 ID 목록과 가벼운 IN 쿼리의 조합으로 처리되므로, API 응답 속도가 크게 향상되고 타임아웃
     문제가 해결됩니다.
   - 코드 안정성 및 유지보수성 향상: DTO 프로젝션과 명시적인 타입 변환을 통해 런타임 오류 가능성을 제거하고, 캐싱 로직과 비즈니스 로직이
     명확하게 분리되어 코드의 안정성과 유지보수성이 향상되었습니다.
